### PR TITLE
sync timestamps to binance server time

### DIFF
--- a/src/main/java/com/binance/api/client/SyncedTime.java
+++ b/src/main/java/com/binance/api/client/SyncedTime.java
@@ -1,0 +1,27 @@
+package com.binance.api.client;
+
+public class SyncedTime {
+    private long offsetServerTime;
+    private static SyncedTime instance;
+
+    private SyncedTime(long offsetServerTime) {
+        this.offsetServerTime = offsetServerTime;
+    }
+
+    public static SyncedTime getInstance(long serverTime) {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (SyncedTime.class) {
+            // currentTime + offset = serverTime; So currentTime - serverTime = -offset
+            long offsetTime = System.currentTimeMillis() - serverTime;
+            instance = new SyncedTime(offsetTime);
+            return instance;
+        }
+    }
+
+    public long currentTimeMillis() {
+        return System.currentTimeMillis() - offsetServerTime;
+    }
+}

--- a/src/main/java/com/binance/api/client/domain/account/NewOrder.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrder.java
@@ -1,5 +1,6 @@
 package com.binance.api.client.domain.account;
 
+import com.binance.api.client.SyncedTime;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.OrderSide;
 import com.binance.api.client.domain.OrderType;
@@ -78,7 +79,7 @@ public class NewOrder {
     this.type = type;
     this.timeInForce = timeInForce;
     this.quantity = quantity;
-    this.timestamp = System.currentTimeMillis();
+    this.timestamp = SyncedTime.getInstance(-1).currentTimeMillis();
     this.recvWindow = BinanceApiConstants.DEFAULT_RECEIVING_WINDOW;
   }
 

--- a/src/main/java/com/binance/api/client/domain/account/request/OrderRequest.java
+++ b/src/main/java/com/binance/api/client/domain/account/request/OrderRequest.java
@@ -1,5 +1,6 @@
 package com.binance.api.client.domain.account.request;
 
+import com.binance.api.client.SyncedTime;
 import com.binance.api.client.constant.BinanceApiConstants;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -17,7 +18,7 @@ public class OrderRequest {
 
   public OrderRequest(String symbol) {
     this.symbol = symbol;
-    this.timestamp = System.currentTimeMillis();
+    this.timestamp = SyncedTime.getInstance(-1).currentTimeMillis();
     this.recvWindow = BinanceApiConstants.DEFAULT_RECEIVING_WINDOW;
   }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -2,6 +2,7 @@ package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiAsyncRestClient;
 import com.binance.api.client.BinanceApiCallback;
+import com.binance.api.client.SyncedTime;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.DepositAddress;
@@ -25,6 +26,8 @@ import com.binance.api.client.domain.market.CandlestickInterval;
 import com.binance.api.client.domain.market.OrderBook;
 import com.binance.api.client.domain.market.TickerPrice;
 import com.binance.api.client.domain.market.TickerStatistics;
+import com.binance.api.client.exception.BinanceApiException;
+import retrofit2.Call;
 
 import java.util.List;
 
@@ -39,6 +42,12 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
 
   public BinanceApiAsyncRestClientImpl(String apiKey, String secret) {
     binanceApiService = createService(BinanceApiService.class, apiKey, secret);
+    binanceApiService.getServerTime().enqueue(new BinanceApiCallbackAdapter<>(new BinanceApiCallback<ServerTime>() {
+      @Override
+      public void onResponse(ServerTime response) throws BinanceApiException {
+        SyncedTime.getInstance(response.getServerTime());
+      }
+    }));
   }
 
   // General endpoints
@@ -150,7 +159,7 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
 
   @Override
   public void getAccount(BinanceApiCallback<Account> callback) {
-    long timestamp = System.currentTimeMillis();
+    long timestamp = SyncedTime.getInstance(-1).currentTimeMillis();
     binanceApiService.getAccount(BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
@@ -161,35 +170,35 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
 
   @Override
   public void getMyTrades(String symbol, Integer limit, BinanceApiCallback<List<Trade>> callback) {
-    getMyTrades(symbol, limit, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis(), callback);
+    getMyTrades(symbol, limit, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis(), callback);
   }
 
   @Override
   public void getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback) {
-    getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis(), callback);
+    getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis(), callback);
   }
 
   @Override
   public void withdraw(String asset, String address, String amount, String name, BinanceApiCallback<Void> callback) {
-    binanceApiService.withdraw(asset, address, amount, name, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis())
+    binanceApiService.withdraw(asset, address, amount, name, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis())
         .enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
   public void getDepositHistory(String asset, BinanceApiCallback<DepositHistory> callback) {
-    binanceApiService.getDepositHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis())
+    binanceApiService.getDepositHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis())
         .enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
   public void getWithdrawHistory(String asset, BinanceApiCallback<WithdrawHistory> callback) {
-    binanceApiService.getWithdrawHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis())
+    binanceApiService.getWithdrawHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis())
         .enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
   public void getDepositAddress(String asset, BinanceApiCallback<DepositAddress> callback) {
-    binanceApiService.getDepositAddress(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis())
+    binanceApiService.getDepositAddress(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis())
         .enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -1,6 +1,7 @@
 package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiRestClient;
+import com.binance.api.client.SyncedTime;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.DepositAddress;
@@ -37,6 +38,7 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
 
   public BinanceApiRestClientImpl(String apiKey, String secret) {
     binanceApiService = createService(BinanceApiService.class, apiKey, secret);
+    SyncedTime.getInstance(this.getServerTime());
   }
 
   // General endpoints
@@ -147,7 +149,7 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
 
   @Override
   public Account getAccount() {
-    return getAccount(BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis());
+    return getAccount(BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis());
   }
 
   @Override
@@ -157,32 +159,32 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
 
   @Override
   public List<Trade> getMyTrades(String symbol, Integer limit) {
-    return getMyTrades(symbol, limit, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis());
+    return getMyTrades(symbol, limit, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis());
   }
 
   @Override
   public List<Trade> getMyTrades(String symbol) {
-    return getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis());
+    return getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis());
   }
 
   @Override
   public void withdraw(String asset, String address, String amount, String name) {
-    executeSync(binanceApiService.withdraw(asset, address, amount, name, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+    executeSync(binanceApiService.withdraw(asset, address, amount, name, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis()));
   }
 
   @Override
   public DepositHistory getDepositHistory(String asset) {
-    return executeSync(binanceApiService.getDepositHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+    return executeSync(binanceApiService.getDepositHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis()));
   }
 
   @Override
   public WithdrawHistory getWithdrawHistory(String asset) {
-    return executeSync(binanceApiService.getWithdrawHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+    return executeSync(binanceApiService.getWithdrawHistory(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis()));
   }
 
   @Override
   public DepositAddress getDepositAddress(String asset) {
-    return executeSync(binanceApiService.getDepositAddress(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+    return executeSync(binanceApiService.getDepositAddress(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, SyncedTime.getInstance(-1).currentTimeMillis()));
   }
 
   // User stream endpoints

--- a/src/test/java/com/binance/api/examples/AccountEndpointsExample.java
+++ b/src/test/java/com/binance/api/examples/AccountEndpointsExample.java
@@ -2,6 +2,7 @@ package com.binance.api.examples;
 
 import com.binance.api.client.BinanceApiClientFactory;
 import com.binance.api.client.BinanceApiRestClient;
+import com.binance.api.client.SyncedTime;
 import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.Trade;
 
@@ -17,7 +18,7 @@ public class AccountEndpointsExample {
     BinanceApiRestClient client = factory.newRestClient();
 
     // Get account balances
-    Account account = client.getAccount(6000000L, System.currentTimeMillis());
+    Account account = client.getAccount(6000000L, SyncedTime.getInstance(-1).currentTimeMillis());
     System.out.println(account.getBalances());
     System.out.println(account.getAssetBalance("ETH"));
 


### PR DESCRIPTION
There is an issue when using this library on different platforms. It doesn't sync to the server properly causing any api calls to fail since the epoch seconds are more than a second apart. This implementation attempts to sync the server and the api client as much as possible. There will be some small time between the return of the server time call and setting the offset for the synced time.
