### PR TITLE
Add Json Serializers for CandlestickEvent and OrderBookEntry

### DIFF
--- a/src/main/java/com/binance/api/client/domain/event/CandlestickEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/CandlestickEvent.java
@@ -1,6 +1,8 @@
 package com.binance.api.client.domain.event;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,6 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * An interval candlestick for a symbol providing informations on price that can be used to produce candlestick charts.
  */
 @JsonDeserialize(using = CandlestickEventDeserializer.class)
+@JsonSerialize(using = CandlestickEventSerializer.class)
 public class CandlestickEvent {
 
   private String eventType;
@@ -31,7 +34,9 @@ public class CandlestickEvent {
   private Long closeTime;
 
   private String intervalId;
+
   private Long firstTradeId;
+
   private Long lastTradeId;
 
   private String quoteAssetVolume;

--- a/src/main/java/com/binance/api/client/domain/event/CandlestickEventSerializer.java
+++ b/src/main/java/com/binance/api/client/domain/event/CandlestickEventSerializer.java
@@ -1,0 +1,44 @@
+package com.binance.api.client.domain.event;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for a candlestick stream event, since the structure of the candlestick json differ from the one in the REST API.
+ *
+ * @see CandlestickEvent
+ */
+public class CandlestickEventSerializer extends JsonSerializer<CandlestickEvent> {
+
+  @Override
+  public void serialize(CandlestickEvent candlestickEvent, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    gen.writeStartObject();
+    
+    // Write header
+    gen.writeStringField("e", candlestickEvent.getEventType());
+    gen.writeNumberField("E", candlestickEvent.getEventTime());
+    gen.writeStringField("s", candlestickEvent.getSymbol());
+    
+    // Write candlestick data
+    gen.writeObjectFieldStart("k");
+    gen.writeNumberField("t", candlestickEvent.getOpenTime());
+    gen.writeNumberField("T", candlestickEvent.getCloseTime());
+    gen.writeStringField("i", candlestickEvent.getIntervalId());
+    gen.writeNumberField("f", candlestickEvent.getFirstTradeId());
+    gen.writeNumberField("L", candlestickEvent.getLastTradeId());
+    gen.writeStringField("o", candlestickEvent.getOpen());
+    gen.writeStringField("c", candlestickEvent.getClose());
+    gen.writeStringField("h", candlestickEvent.getHigh());
+    gen.writeStringField("l", candlestickEvent.getLow());
+    gen.writeStringField("v", candlestickEvent.getVolume());
+    gen.writeNumberField("n", candlestickEvent.getNumberOfTrades());
+    gen.writeBooleanField("x", candlestickEvent.getBarFinal());
+    gen.writeStringField("q", candlestickEvent.getQuoteAssetVolume());
+    gen.writeStringField("V", candlestickEvent.getTakerBuyBaseAssetVolume());
+    gen.writeStringField("Q", candlestickEvent.getTakerBuyQuoteAssetVolume());
+    gen.writeEndObject();
+  }
+}

--- a/src/main/java/com/binance/api/client/domain/market/OrderBookEntry.java
+++ b/src/main/java/com/binance/api/client/domain/market/OrderBookEntry.java
@@ -1,6 +1,8 @@
 package com.binance.api.client.domain.market;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -8,7 +10,9 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * An order book entry consisting of price and quantity.
  */
 @JsonDeserialize(using = OrderBookEntryDeserializer.class)
+@JsonSerialize(using = OrderBookEntrySerializer.class)
 public class OrderBookEntry {
+
   private String price;
   private String qty;
 

--- a/src/main/java/com/binance/api/client/domain/market/OrderBookEntrySerializer.java
+++ b/src/main/java/com/binance/api/client/domain/market/OrderBookEntrySerializer.java
@@ -1,0 +1,21 @@
+package com.binance.api.client.domain.market;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for an OrderBookEntry.
+ */
+public class OrderBookEntrySerializer extends JsonSerializer<OrderBookEntry> {
+
+  @Override
+  public void serialize(OrderBookEntry orderBookEntry, JsonGenerator gen, SerializerProvider serializers) throws IOException {    
+    gen.writeStartArray();
+    gen.writeString(orderBookEntry.getPrice());
+    gen.writeString(orderBookEntry.getQty());
+    gen.writeEndArray();
+  }
+}


### PR DESCRIPTION
This is used to make the events serializable which is desired if a user wants to dump the events on disk to analyze them later.