### PR TITLE
fix-objectmapper

### DIFF
--- a/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEventDeserializer.java
+++ b/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEventDeserializer.java
@@ -17,8 +17,15 @@ import java.io.IOException;
  */
 public class UserDataUpdateEventDeserializer extends JsonDeserializer<UserDataUpdateEvent> {
 
+  private ObjectMapper mapper;
+
   @Override
   public UserDataUpdateEvent deserialize(JsonParser jp, DeserializationContext ctx) throws IOException {
+
+    if (mapper == null){
+      mapper = new ObjectMapper();
+    }
+
     ObjectCodec oc = jp.getCodec();
     JsonNode node = oc.readTree(jp);
     String json = node.toString();
@@ -32,18 +39,17 @@ public class UserDataUpdateEventDeserializer extends JsonDeserializer<UserDataUp
     userDataUpdateEvent.setEventTime(eventTime);
 
     if (userDataUpdateEventType == UserDataUpdateEventType.ACCOUNT_UPDATE) {
-      AccountUpdateEvent accountUpdateEvent = getUserDataUpdateEventDetail(json, AccountUpdateEvent.class);
+      AccountUpdateEvent accountUpdateEvent = getUserDataUpdateEventDetail(json, AccountUpdateEvent.class, mapper);
       userDataUpdateEvent.setAccountUpdateEvent(accountUpdateEvent);
     } else { // userDataUpdateEventType == UserDataUpdateEventType.ORDER_TRADE_UPDATE
-      OrderTradeUpdateEvent orderTradeUpdateEvent = getUserDataUpdateEventDetail(json, OrderTradeUpdateEvent.class);
+      OrderTradeUpdateEvent orderTradeUpdateEvent = getUserDataUpdateEventDetail(json, OrderTradeUpdateEvent.class, mapper);
       userDataUpdateEvent.setOrderTradeUpdateEvent(orderTradeUpdateEvent);
     }
 
     return userDataUpdateEvent;
   }
 
-  public <T> T getUserDataUpdateEventDetail(String json, Class<T> clazz) {
-    ObjectMapper mapper = new ObjectMapper();
+  public <T> T getUserDataUpdateEventDetail(String json, Class<T> clazz, ObjectMapper mapper) {
     try {
       return mapper.readValue(json, clazz);
     } catch (IOException e) {

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
@@ -18,14 +18,20 @@ public class BinanceApiWebSocketListener<T> extends WebSocketListener {
 
   private Class<T> eventClass;
 
+  private ObjectMapper mapper;
+
   public BinanceApiWebSocketListener(BinanceApiCallback<T> callback, Class<T> eventClass) {
+    this(callback, eventClass, new ObjectMapper());
+  }
+
+  public BinanceApiWebSocketListener(BinanceApiCallback<T> callback, Class<T> eventClass, ObjectMapper mapper) {
     this.callback = callback;
     this.eventClass = eventClass;
+    this.mapper = mapper;
   }
 
   @Override
   public void onMessage(WebSocket webSocket, String text) {
-    ObjectMapper mapper = new ObjectMapper();
     try {
       T event = mapper.readValue(text, eventClass);
       callback.onResponse(event);


### PR DESCRIPTION
Resolves #29

Normally, you would only use a single Jackson ObjectMapper per the entire app, injected via DI or any other means. 
However, after looking at the current code, there's no way to delegate ObjectMapper construction in UserDataUpdateEventDeserializer.
Hence for this edge case, it is created lazily on first access instead of recreating it each time on deserialization.