### PR TITLE
Add callback null event on websocket failure

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
@@ -42,6 +42,7 @@ public class BinanceApiWebSocketListener<T> extends WebSocketListener {
 
   @Override
   public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+    callback.onResponse(null);
     throw new BinanceApiException(t);
   }
 }


### PR DESCRIPTION
I added this event to have a chance to do something on callback when the websocket fails.

E.g. it allows to restart the event listener after failure like so:

```java
    static void startAggTradeEventListener(BinanceApiClientFactory factory, String symbol, ExchangeApiCallback<AggTradeEvent> callback) {
        BinanceApiWebSocketClient client = factory.newWebSocketClient();
        client.onAggTradeEvent(symbol, (AggTradeEvent event) -> {
            if (event == null) {
                startAggTradeEventListener(factory, symbol, callback);
            }
            else {
                callback.onResponse(event);
            }
        });
    }
```