### PR TITLE
Expose the 'U' (first update), as well as the 'u' (final update) on Depth Event

### DIFF
--- a/src/main/java/com/binance/api/client/domain/event/DepthEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/DepthEvent.java
@@ -84,12 +84,18 @@ public class DepthEvent {
     this.finalUpdateId = finalUpdateId;
   }
 
-  @Deprecated // Use getFinalUpdateId
+  /**
+   * @deprecated Use {@link #getFinalUpdateId}
+   */
+  @Deprecated
   public long getUpdateId() {
     return finalUpdateId;
   }
 
-  @Deprecated // Use setFinalUpdateId
+  /**
+   * @deprecated Use {@link #setFinalUpdateId}
+   */
+  @Deprecated
   public void setUpdateId(long updateId) {
     this.finalUpdateId = updateId;
   }

--- a/src/main/java/com/binance/api/client/domain/event/DepthEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/DepthEvent.java
@@ -23,11 +23,14 @@ public class DepthEvent {
   @JsonProperty("s")
   private String symbol;
 
+  @JsonProperty("U")
+  private long firstUpdateId;
+
   /**
    * updateId to sync up with updateid in /api/v1/depth
    */
   @JsonProperty("u")
-  private long updateId;
+  private long finalUpdateId;
 
   /**
    * Bid depth delta.
@@ -65,12 +68,30 @@ public class DepthEvent {
     this.symbol = symbol;
   }
 
-  public long getUpdateId() {
-    return updateId;
+  public long getFirstUpdateId() {
+    return firstUpdateId;
   }
 
+  public void setFirstUpdateId(final long firstUpdateId) {
+    this.firstUpdateId = firstUpdateId;
+  }
+
+  public long getFinalUpdateId() {
+    return finalUpdateId;
+  }
+
+  public void setFinalUpdateId(long finalUpdateId) {
+    this.finalUpdateId = finalUpdateId;
+  }
+
+  @Deprecated // Use getFinalUpdateId
+  public long getUpdateId() {
+    return finalUpdateId;
+  }
+
+  @Deprecated // Use setFinalUpdateId
   public void setUpdateId(long updateId) {
-    this.updateId = updateId;
+    this.finalUpdateId = updateId;
   }
 
   public List<OrderBookEntry> getBids() {
@@ -95,7 +116,8 @@ public class DepthEvent {
         .append("eventType", eventType)
         .append("eventTime", eventTime)
         .append("symbol", symbol)
-        .append("updateId", updateId)
+        .append("firstUpdateId", firstUpdateId)
+        .append("finalUpdateId", finalUpdateId)
         .append("bids", bids)
         .append("asks", asks)
         .toString();

--- a/src/test/java/com/binance/api/examples/DepthCacheExample.java
+++ b/src/test/java/com/binance/api/examples/DepthCacheExample.java
@@ -63,9 +63,9 @@ public class DepthCacheExample {
     BinanceApiWebSocketClient client = factory.newWebSocketClient();
 
     client.onDepthEvent(symbol.toLowerCase(), response -> {
-      if (response.getUpdateId() > lastUpdateId) {
+      if (response.getFinalUpdateId() > lastUpdateId) {
         System.out.println(response);
-        lastUpdateId = response.getUpdateId();
+        lastUpdateId = response.getFinalUpdateId();
         updateOrderBook(getAsks(), response.getAsks());
         updateOrderBook(getBids(), response.getBids());
         printDepthCache();
@@ -125,9 +125,9 @@ public class DepthCacheExample {
    */
   private void printDepthCache() {
     System.out.println(depthCache);
-    System.out.println("ASKS:");
+    System.out.println("ASKS:(" + getAsks().size() + ")");
     getAsks().entrySet().forEach(entry -> System.out.println(toDepthCacheEntryString(entry)));
-    System.out.println("BIDS:");
+    System.out.println("BIDS:(" + getBids().size() + ")");
     getBids().entrySet().forEach(entry -> System.out.println(toDepthCacheEntryString(entry)));
     System.out.println("BEST ASK: " + toDepthCacheEntryString(getBestAsk()));
     System.out.println("BEST BID: " + toDepthCacheEntryString(getBestBid()));


### PR DESCRIPTION
Hey,

Looking at the docs, it looks like its not possible to maintain a valid cache of open orders without back the 'U' and 'u' field on the Depth event, but only one was exposed. This PR exposes the other. I've left the old accessors in there for backwards compatibility, or they could be removed...

BTW - the example the `DepthCacheExample` does not subscribe to changes via the WS api before getting a snapshot from the rest API, which is what is recommended by your docs.

Also, if you run the example, you'll notice that the number of bid and ask orders increases over time and sometimes drops below the original snapshot size.  I would of expected a consistent cache size after each update. Not sure if there is something that can be done to avoid this? 

Thanks!

Andy