### PR TITLE
Expose WebSockets for graceful closing

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -6,16 +6,18 @@ import com.binance.api.client.domain.event.DepthEvent;
 import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 
+import okhttp3.WebSocket;
+
 /**
  * Binance API data streaming façade, supporting streaming of events through web sockets.
  */
 public interface BinanceApiWebSocketClient {
 
-  void onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
+  WebSocket onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
 
-  void onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
+  WebSocket onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
 
-  void onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
+  WebSocket onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
 
-  void onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
+  WebSocket onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -10,6 +10,7 @@ import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.WebSocket;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -25,30 +26,31 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
     this.client = new OkHttpClient();
   }
 
-  public void onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
+  @Override
+  public WebSocket onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
     final String channel = String.format("%s@depth", symbol);
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
   }
 
   @Override
-  public void onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
+  public WebSocket onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
     final String channel = String.format("%s@kline_%s", symbol, interval.getIntervalId());
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
   }
 
-  public void onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
+  public WebSocket onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
     final String channel = String.format("%s@aggTrade", symbol);
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
   }
 
-  public void onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
-    createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
+  public WebSocket onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
+    return createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
   }
 
-  private void createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
+  private WebSocket createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
     String streamingUrl = String.format("%s/%s", BinanceApiConstants.WS_API_BASE_URL, channel);
     Request request = new Request.Builder().url(streamingUrl).build();
-    client.newWebSocket(request, listener);
+    return client.newWebSocket(request, listener);
   }
 
   @Override


### PR DESCRIPTION
Binance disconnects after 24 hours of websocket streaming. To prevent this, we should be able to open a new websocket, and switch over to the new one, before the 24h mark. After the live switchover, we need to be able to close the original one. Exposing the okhttp.WebSocket allows us to perform: `.close()`.