### PR TITLE
Error handling and shutdown improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ BinanceApiWebSocketClient client = BinanceApiClientFactory.newInstance().newWebS
 
 #### Handling web socket errors
 
-Each of the methods `BinanceApiWebSocketClient` which open a new web socket takes a `BinanceApiCallback`, which is
+Each of the methods on `BinanceApiWebSocketClient`, which opens a new web socket, takes a `BinanceApiCallback`, which is
 called for each event received from the Binance servers. 
 
 The `BinanceApiCallback` interface also has a `onFailure(Throwable)` method, which, optionally, can be implemented to 
@@ -304,7 +304,7 @@ client.onAggTradeEvent(symbol.toLowerCase(), new BinanceApiCallback<AggTradeEven
 
 #### Closing web sockets
 
-Each of the methods `BinanceApiWebSocketClient` which open a new web socket also return a `Closeable`.
+Each of the methods on `BinanceApiWebSocketClient`, which opens a new web socket, also returns a `Closeable`.
 This `Closeable` can be used to close the underlying web socket and free any associated resources, e.g.
 
 ```java

--- a/README.md
+++ b/README.md
@@ -279,6 +279,40 @@ client.closeUserDataStream(listenKey);
 BinanceApiWebSocketClient client = BinanceApiClientFactory.newInstance().newWebSocketClient();
 ```
 
+#### Handling web socket errors
+
+Each of the methods `BinanceApiWebSocketClient` which open a new web socket takes a `BinanceApiCallback`, which is
+called for each event received from the Binance servers. 
+
+The `BinanceApiCallback` interface also has a `onFailure(Throwable)` method, which, optionally, can be implemented to 
+receive notifications if the web-socket fails, e.g. disconnection.   
+
+```java
+client.onAggTradeEvent(symbol.toLowerCase(), new BinanceApiCallback<AggTradeEvent>() {
+    @Override
+    public void onResponse(final AggTradeEvent response) {
+        System.out.println(response);
+    }
+
+    @Override
+    public void onFailure(final Throwable cause) {
+        System.err.println("Web socket failed");
+        cause.printStackTrace(System.err);
+    }
+});
+```
+
+#### Closing web sockets
+
+Each of the methods `BinanceApiWebSocketClient` which open a new web socket also return a `Closeable`.
+This `Closeable` can be used to close the underlying web socket and free any associated resources, e.g.
+
+```java
+Closable ws = client.onAggTradeEvent("ethbtc", someCallback);
+// some time later...
+ws.close();
+```
+
 #### Listen for aggregated trade events for ETH/BTC
 ```java
 client.onAggTradeEvent("ethbtc", (AggTradeEvent response) -> {

--- a/src/main/java/com/binance/api/client/BinanceApiCallback.java
+++ b/src/main/java/com/binance/api/client/BinanceApiCallback.java
@@ -1,19 +1,24 @@
 package com.binance.api.client;
 
-import com.binance.api.client.exception.BinanceApiException;
-
 /**
  * BinanceApiCallback is a functional interface used together with the BinanceApiAsyncClient to provide a non-blocking REST client.
  *
  * @param <T> the return type from the callback
  */
+@FunctionalInterface
 public interface BinanceApiCallback<T> {
 
     /**
      * Called whenever a response comes back from the Binance API.
      *
      * @param response the expected response object
-     * @throws BinanceApiException if it is not possible to obtain the expected response object (e.g. incorrect API-KEY).
      */
-    void onResponse(T response) throws BinanceApiException;
+    void onResponse(T response);
+
+    /**
+     * Called whenever an error occurs.
+     *
+     * @param cause the cause of the failure
+     */
+    default void onFailure(Throwable cause) {}
 }

--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -6,16 +6,20 @@ import com.binance.api.client.domain.event.DepthEvent;
 import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 
+import java.io.Closeable;
+
 /**
  * Binance API data streaming façade, supporting streaming of events through web sockets.
  */
-public interface BinanceApiWebSocketClient {
+public interface BinanceApiWebSocketClient extends Closeable {
 
-  void onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
+  Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
 
-  void onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
+  Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
 
-  void onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
+  Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
 
-  void onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
+  Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
+
+  void close();
 }

--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -1,6 +1,5 @@
 package com.binance.api.client;
 
-import java.util.List;
 import com.binance.api.client.domain.event.AggTradeEvent;
 import com.binance.api.client.domain.event.AllMarketTickersEvent;
 import com.binance.api.client.domain.event.CandlestickEvent;
@@ -9,21 +8,57 @@ import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 
 import java.io.Closeable;
+import java.util.List;
 
 /**
  * Binance API data streaming façade, supporting streaming of events through web sockets.
  */
 public interface BinanceApiWebSocketClient extends Closeable {
 
-  Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
+    /**
+     * Open a new web socket to receive {@link DepthEvent depthEvents} on a callback.
+     *
+     * @param symbol   the market symbol to subscribe to
+     * @param callback the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
 
-  Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
+    /**
+     * Open a new web socket to receive {@link CandlestickEvent candlestickEvents} on a callback.
+     *
+     * @param symbol   the market symbol to subscribe to
+     * @param interval the interval of the candles tick events required
+     * @param callback the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
 
-  Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
+    /**
+     * Open a new web socket to receive {@link AggTradeEvent aggTradeEvents} on a callback.
+     *
+     * @param symbol   the market symbol to subscribe to
+     * @param callback the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
 
-  Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
+    /**
+     * Open a new web socket to receive {@link UserDataUpdateEvent userDataUpdateEvents} on a callback.
+     *
+     * @param listenKey the listen key to subscribe to.
+     * @param callback  the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback);
 
-  Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback);
-  
-  void close();
+    /**
+     * Open a new web socket to receive {@link AllMarketTickersEvent allMarketTickersEvents} on a callback.
+     *
+     * @param callback the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback);
+
+    void close();
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -10,9 +10,9 @@ import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.WebSocket;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 /**
  * Binance API WebSocket client implementation using OkHttp.
@@ -25,34 +25,40 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
     this.client = new OkHttpClient();
   }
 
-  public void onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
+  public Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
     final String channel = String.format("%s@depth", symbol);
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
   }
 
   @Override
-  public void onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
+  public Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
     final String channel = String.format("%s@kline_%s", symbol, interval.getIntervalId());
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
   }
 
-  public void onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
+  public Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
     final String channel = String.format("%s@aggTrade", symbol);
-    createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
+    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
   }
 
-  public void onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
-    createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
+  public Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
+    return createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
   }
 
-  private void createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
+  private Closeable createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
     String streamingUrl = String.format("%s/%s", BinanceApiConstants.WS_API_BASE_URL, channel);
     Request request = new Request.Builder().url(streamingUrl).build();
-    client.newWebSocket(request, listener);
+    final WebSocket webSocket = client.newWebSocket(request, listener);
+    return () -> {
+      final int code = 1000;
+      listener.onClosing(webSocket, code, null);
+      webSocket.close(code, null);
+      listener.onClosed(webSocket, code, null);
+    };
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     client.dispatcher().executorService().shutdown();
   }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -1,11 +1,5 @@
 package com.binance.api.client.impl;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.List;
-import okhttp3.Dispatcher;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import com.binance.api.client.BinanceApiCallback;
 import com.binance.api.client.BinanceApiWebSocketClient;
 import com.binance.api.client.constant.BinanceApiConstants;
@@ -15,64 +9,66 @@ import com.binance.api.client.domain.event.CandlestickEvent;
 import com.binance.api.client.domain.event.DepthEvent;
 import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 
 import java.io.Closeable;
+import java.util.List;
 
 /**
  * Binance API WebSocket client implementation using OkHttp.
  */
 public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient, Closeable {
 
-  private OkHttpClient client;
+    private OkHttpClient client;
 
-  public BinanceApiWebSocketClientImpl() {
-    Dispatcher d = new Dispatcher();
-    d.setMaxRequestsPerHost(100);
-    this.client = new OkHttpClient.Builder().dispatcher(d).build();
-  }
+    public BinanceApiWebSocketClientImpl() {
+        Dispatcher d = new Dispatcher();
+        d.setMaxRequestsPerHost(100);
+        this.client = new OkHttpClient.Builder().dispatcher(d).build();
+    }
 
-  public Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
-    final String channel = String.format("%s@depth", symbol);
-    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
-  }
+    public Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
+        final String channel = String.format("%s@depth", symbol);
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
+    }
 
-  @Override
-  public Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
-    final String channel = String.format("%s@kline_%s", symbol, interval.getIntervalId());
-    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
-  }
+    @Override
+    public Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
+        final String channel = String.format("%s@kline_%s", symbol, interval.getIntervalId());
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
+    }
 
-  public Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
-    final String channel = String.format("%s@aggTrade", symbol);
-    return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
-  }
+    public Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
+        final String channel = String.format("%s@aggTrade", symbol);
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
+    }
 
-  public Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
-    return createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
-  }
-  
-  public Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback) {
-    final String channel = "!ticker@arr";
-    return createNewWebSocket(channel, new BinanceApiWebSocketListener<List<AllMarketTickersEvent>>(callback));
-  }
-  
-  @Override
-  public void close() {
-    client.dispatcher().executorService().shutdown();
-  }
+    public Closeable onUserDataUpdateEvent(String listenKey, BinanceApiCallback<UserDataUpdateEvent> callback) {
+        return createNewWebSocket(listenKey, new BinanceApiWebSocketListener<>(callback, UserDataUpdateEvent.class));
+    }
 
-  private Closeable createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
-    String streamingUrl = String.format("%s/%s", BinanceApiConstants.WS_API_BASE_URL, channel);
-    Request request = new Request.Builder().url(streamingUrl).build();
-    final WebSocket webSocket = client.newWebSocket(request, listener);
-    return () -> {
-      final int code = 1000;
-      listener.onClosing(webSocket, code, null);
-      webSocket.close(code, null);
-      listener.onClosed(webSocket, code, null);
-    };
-  } 
+    public Closeable onAllMarketTickersEvent(BinanceApiCallback<List<AllMarketTickersEvent>> callback) {
+        final String channel = "!ticker@arr";
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<List<AllMarketTickersEvent>>(callback));
+    }
+
+    @Override
+    public void close() {
+        client.dispatcher().executorService().shutdown();
+    }
+
+    private Closeable createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
+        String streamingUrl = String.format("%s/%s", BinanceApiConstants.WS_API_BASE_URL, channel);
+        Request request = new Request.Builder().url(streamingUrl).build();
+        final WebSocket webSocket = client.newWebSocket(request, listener);
+        return () -> {
+            final int code = 1000;
+            listener.onClosing(webSocket, code, null);
+            webSocket.close(code, null);
+            listener.onClosed(webSocket, code, null);
+        };
+    }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketListener.java
@@ -20,6 +20,8 @@ public class BinanceApiWebSocketListener<T> extends WebSocketListener {
 
   private ObjectMapper mapper;
 
+  private boolean closing = false;
+
   public BinanceApiWebSocketListener(BinanceApiCallback<T> callback, Class<T> eventClass) {
     this(callback, eventClass, new ObjectMapper());
   }
@@ -41,7 +43,14 @@ public class BinanceApiWebSocketListener<T> extends WebSocketListener {
   }
 
   @Override
+  public void onClosing(final WebSocket webSocket, final int code, final String reason) {
+    closing = true;
+  }
+
+  @Override
   public void onFailure(WebSocket webSocket, Throwable t, Response response) {
-    throw new BinanceApiException(t);
+    if (!closing) {
+      callback.onFailure(t);
+    }
   }
 }


### PR DESCRIPTION
This PR should hopefully improve the error handling in the client and allow users to shutdown the client and/or a active web socket.

- Optional `onFailure` added to `BinanceApiCallback` to allow user to opt-in to receiving failure info, (Note: the interfacer remains a functional one for simple use-cases, it just now also supports error handling for when you care about such things).
- `BinanceApiWebSocketClient` enhanced to return `Closeable`s from calls creating web sockets, so that said web sockets can be later closed, if needed.
- `BinanceApiWebSocketClient` enhanced to be `Closeable` itself, closing the internal OKHttp dispatcher.
- `BinanceApiWebSocketListener` no longer throws an exception from `onFailure`, as this was just being thrown up the stack to the `Thread.uncaughtExceptionHandler`.

With these changes I can now:
- detect failures on the web socket and choose to do something about them.
- shutdown the `BinanceApiWebSocketClient`, and potentially recreate later, without any resource leaks or references being held to my callback objects.