### PR TITLE
Allow up to 100 connections to binance.

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -9,6 +9,7 @@ import com.binance.api.client.domain.event.DepthEvent;
 import com.binance.api.client.domain.event.UserDataUpdateEvent;
 import com.binance.api.client.domain.market.CandlestickInterval;
 import okhttp3.OkHttpClient;
+import okhttp3.Dispatcher;
 import okhttp3.Request;
 
 import java.io.Closeable;
@@ -22,7 +23,9 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
   private OkHttpClient client;
 
   public BinanceApiWebSocketClientImpl() {
-    this.client = new OkHttpClient();
+    Dispatcher d = new Dispatcher();
+    d.setMaxRequestsPerHost(100);
+    this.client = new OkHttpClient.Builder().dispatcher(d).build();
   }
 
   public void onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {


### PR DESCRIPTION
OkHTTP3 limits the amount of connections to the same host to 5. This means you cannot open more than 5 steams of events. Truly undesirable within this context. I increased the amount to 100, for ease of use.

Having it on the default of 5, just causes you to be able to open websockets, but they wont provide you with any data. We tested this, and this fix resolves the issue.