### PR TITLE
Fix for issue #54

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Annotation;
  */
 public class BinanceApiServiceGenerator {
 
-    private static OkHttpClient.Builder httpClient = new OkHttpClient.Builder();
+    static OkHttpClient.Builder httpClient = new OkHttpClient.Builder();
 
     private static Retrofit.Builder builder =
         new Retrofit.Builder()

--- a/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
@@ -10,6 +10,7 @@ import okio.Buffer;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A request interceptor that injects the API Key Header into requests, and signs messages, whenever required.
@@ -73,5 +74,19 @@ public class AuthenticationInterceptor implements Interceptor {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final AuthenticationInterceptor that = (AuthenticationInterceptor) o;
+        return Objects.equals(apiKey, that.apiKey) &&
+                Objects.equals(secret, that.secret);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(apiKey, secret);
     }
 }

--- a/src/test/java/com/binance/api/client/impl/BinanceApiServiceGeneratorTest.java
+++ b/src/test/java/com/binance/api/client/impl/BinanceApiServiceGeneratorTest.java
@@ -1,0 +1,24 @@
+package com.binance.api.client.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author andy coates
+ * created 08/02/2018.
+ */
+public class BinanceApiServiceGeneratorTest {
+    @Test
+    public void shouldOnlyAddAuthInterceptorOnce() throws Exception {
+        // Given:
+        BinanceApiServiceGenerator.createService(BinanceApiService.class, "someKey", "someValue");
+        final int initialSize = BinanceApiServiceGenerator.httpClient.interceptors().size();
+
+        // When:
+        BinanceApiServiceGenerator.createService(BinanceApiService.class, "someKey", "someValue");
+
+        // Then
+        assertEquals(BinanceApiServiceGenerator.httpClient.interceptors().size(), initialSize);
+    }
+}


### PR DESCRIPTION
Issue #54 sees client applications eventually failing with a `StackOverflowException`.

This is caused by repeatedly call creating new clients, (i.e. rest or ws), rather than caching.

Each time a new client is created this code is invoked (from https://github.com/binance-exchange/binance-java-api/blob/master/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java#L38):

```java
public static <S> S createService(Class<S> serviceClass, String apiKey, String secret) {
        if (!StringUtils.isEmpty(apiKey) && !StringUtils.isEmpty(secret)) {
            AuthenticationInterceptor interceptor = new AuthenticationInterceptor(apiKey, secret);
            if (!httpClient.interceptors().contains(interceptor)) {
                httpClient.addInterceptor(interceptor);
                builder.client(httpClient.build());
                retrofit = builder.build();
            }
        }
        return retrofit.create(serviceClass);
    }
```

The issue is that `AuthenticationInterceptor` does not implement `hashCode` and `equals`, so the `contains` check does NOT find any preexisting instance of the `AuthenticationInterceptor` and adds a new one each time... eventually leading to stack overflow.

This PR adds the necessary `hashCode` and `equals` impls...
