### PR TITLE
Overloaded method to use one ws connection for many symbols

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -35,6 +35,16 @@ public interface BinanceApiWebSocketClient extends Closeable {
     Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
 
     /**
+     * Open a new web socket to receive {@link CandlestickEvent candlestickEvents} on a callback.
+     *
+     * @param symbols list of market symbols to subscribe to
+     * @param interval the interval of the candles tick events required
+     * @param callback the callback to call on new events
+     * @return a {@link Closeable} that allows the underlying web socket to be closed.
+     */
+    Closeable onCandlestickEvent(List<String> symbols, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
+
+    /**
      * Open a new web socket to receive {@link AggTradeEvent aggTradeEvents} on a callback.
      *
      * @param symbol   the market symbol to subscribe to

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -41,6 +41,12 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
     }
 
+    @Override
+    public Closeable onCandlestickEvent(List<String> symbols, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
+        final String channel = symbols.stream().map((symbol) -> String.format("%s@kline_%s", symbol, interval.getIntervalId())).reduce((symbol1, symbol2) -> symbol1 + "/" + symbol2).get();
+        return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
+    }
+
     public Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
         final String channel = String.format("%s@aggTrade", symbol);
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));


### PR DESCRIPTION
BInance allows websocket requests to be made with multiple symbols.  This will allow for one connection to be made if wanting multiple candlesticks and ultimately not get IP banned (if testing a lot)