### PR TITLE
Add support for AllAssets

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -14,6 +14,7 @@ import com.binance.api.client.domain.account.request.CancelOrderRequest;
 import com.binance.api.client.domain.account.request.OrderRequest;
 import com.binance.api.client.domain.account.request.OrderStatusRequest;
 import com.binance.api.client.domain.general.ExchangeInfo;
+import com.binance.api.client.domain.general.AllAssets;
 import com.binance.api.client.domain.market.AggTrade;
 import com.binance.api.client.domain.market.BookTicker;
 import com.binance.api.client.domain.market.Candlestick;
@@ -42,6 +43,11 @@ public interface BinanceApiRestClient {
    * @return current server time.
    */
   Long getServerTime();
+
+  /**
+   * @return All the assets Binance supports and whether or not they can be withdrawn.
+   */
+  AllAssets getAllAssets();
 
   /**
    * @return Current exchange trading rules and symbol information
@@ -123,7 +129,7 @@ public interface BinanceApiRestClient {
    * @param symbol ticker symbol (e.g. ETHBTC)
    */
   TickerStatistics get24HrPriceStatistics(String symbol);
-  
+
   /**
    * Get 24 hour price change statistics for all symbols.
    */
@@ -133,10 +139,10 @@ public interface BinanceApiRestClient {
    * Get Latest price for all symbols.
    */
   List<TickerPrice> getAllPrices();
-  
+
   /**
    * Get latest price for <code>symbol</code>.
-   * 
+   *
    * @param symbol ticker symbol (e.g. ETHBTC)
    */
   TickerPrice getPrice(String symbol);

--- a/src/main/java/com/binance/api/client/domain/general/AllAssets.java
+++ b/src/main/java/com/binance/api/client/domain/general/AllAssets.java
@@ -1,0 +1,123 @@
+package com.binance.api.client.domain.general;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * All assets Binance supports.
+ */
+ @JsonIgnoreProperties(ignoreUnknown = true)
+ public class AllAssets {
+
+   @JsonProperty("id")
+   private String id;
+
+   @JsonProperty("assetCode")
+   private String assetCode;
+
+   @JsonProperty("assetName")
+   private String assetName;
+
+   @JsonProperty("unit")
+   private String unit;
+
+   @JsonProperty("transactionFee")
+   private long transactionFee;
+
+   @JsonProperty("commissionRate")
+   private long commissionRate;
+
+   @JsonProperty("freeAuditWithdrawAmt")
+   private long freeAuditWithdrawAmount;
+
+   @JsonProperty("freeUserChargeAmount")
+   private long freeUserChargeAmount;
+
+   @JsonProperty("minProductWithdraw")
+   private long minProductWithdraw;
+
+   @JsonProperty("withdrawIntegerMultiple")
+   private long withdrawIntegerMultiple;
+
+   @JsonProperty("confirmTimes")
+   private long confirmTimes;
+
+   @JsonProperty("enableWithdraw")
+   private boolean enableWithdraw;
+
+   @JsonProperty("isLegalMoney")
+   private boolean isLegalMoney;
+
+   public String getId() {
+     return id;
+   }
+
+   public String getAssetCode() {
+     return assetCode;
+   }
+
+   public String getAssetName() {
+     return assetName;
+   }
+
+   public String getUnit() {
+     return unit;
+   }
+
+   public long getTransactionFee() {
+     return transactionFee;
+   }
+
+   public long getCommissionRate() {
+     return commissionRate;
+   }
+
+   public long getFreeAuditWithdrawAmount() {
+     return freeAuditWithdrawAmount;
+   }
+
+   public long getFreeUserChargeAmount() {
+     return freeUserChargeAmount;
+   }
+
+   public long minProductWithdraw() {
+     return minProductWithdraw;
+   }
+
+   public long getWithdrawIntegerMultiple() {
+     return withdrawIntegerMultiple;
+   }
+
+   public long getConfirmTimes() {
+     return confirmTimes;
+   }
+
+   public long canWithraw() {
+     return enableWithdraw;
+   }
+
+   public long isLegalMoney() {
+     return isLegalMoney;
+   }
+
+   @Override
+   public String toString() {
+     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+         .append("id", id)
+         .append("assetCode", assetCode)
+         .append("assetName", assetName)
+         .append("unit", unit)
+         .append("transactionFee", transactionFee)
+         .append("commissionRate", commissionRate)
+         .append("freeAuditWithdrawAmount", freeAuditWithdrawAmount)
+         .append("freeUserChargeAmount", freeUserChargeAmount)
+         .append("minProductWithdraw", minProductWithdraw)
+         .append("withdrawIntegerMultiple", withdrawIntegerMultiple)
+         .append("confirmTimes", confirmTimes)
+         .append("enableWithdraw", enableWithdraw)
+         .append("isLegalMoney", isLegalMoney)
+         .toString();
+   }
+ }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -17,6 +17,7 @@ import com.binance.api.client.domain.account.request.CancelOrderRequest;
 import com.binance.api.client.domain.account.request.OrderRequest;
 import com.binance.api.client.domain.account.request.OrderStatusRequest;
 import com.binance.api.client.domain.event.ListenKey;
+import com.binance.api.client.domain.general.AllAssets;
 import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.general.ServerTime;
 import com.binance.api.client.domain.market.AggTrade;
@@ -52,6 +53,11 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
   @Override
   public void getServerTime(BinanceApiCallback<ServerTime> callback) {
     binanceApiService.getServerTime().enqueue(new BinanceApiCallbackAdapter<>(callback));
+  }
+
+  @Override
+  public void getAllAssets(BinanceApiCallback<AllAssets> callback) {
+    binanceApiService.getAllAssets().enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
@@ -100,7 +106,7 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
   public void get24HrPriceStatistics(String symbol, BinanceApiCallback<TickerStatistics> callback) {
     binanceApiService.get24HrPriceStatistics(symbol).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
-  
+
   @Override
   public void getAll24HrPriceStatistics(BinanceApiCallback<List<TickerStatistics>> callback) {
     binanceApiService.getAll24HrPriceStatistics().enqueue(new BinanceApiCallbackAdapter<>(callback));
@@ -110,7 +116,7 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
   public void getAllPrices(BinanceApiCallback<List<TickerPrice>> callback) {
     binanceApiService.getLatestPrices().enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
-  
+
   @Override
   public void getPrice(String symbol , BinanceApiCallback<TickerPrice> callback) {
     binanceApiService.getLatestPrice(symbol).enqueue(new BinanceApiCallbackAdapter<>(callback));

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -15,6 +15,7 @@ import com.binance.api.client.domain.account.request.AllOrdersRequest;
 import com.binance.api.client.domain.account.request.CancelOrderRequest;
 import com.binance.api.client.domain.account.request.OrderRequest;
 import com.binance.api.client.domain.account.request.OrderStatusRequest;
+import com.binance.api.client.domain.general.AllAssets;
 import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.market.AggTrade;
 import com.binance.api.client.domain.market.BookTicker;
@@ -50,6 +51,11 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
   @Override
   public Long getServerTime() {
     return executeSync(binanceApiService.getServerTime()).getServerTime();
+  }
+
+  @Override
+  public AllAssets getAllAssets() {
+    return executeSync(binanceApiService.getAllAssets());
   }
 
   @Override
@@ -108,7 +114,7 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
   public TickerPrice getPrice(String symbol) {
 	  return executeSync(binanceApiService.getLatestPrice(symbol));
   }
-  
+
   @Override
   public List<TickerPrice> getAllPrices() {
     return executeSync(binanceApiService.getLatestPrices());

--- a/src/main/java/com/binance/api/client/impl/BinanceApiService.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiService.java
@@ -15,6 +15,7 @@ import com.binance.api.client.domain.account.WithdrawHistory;
 import com.binance.api.client.domain.event.ListenKey;
 import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.general.ServerTime;
+import com.binance.api.client.domain.general.AllAssets;
 import com.binance.api.client.domain.market.AggTrade;
 import com.binance.api.client.domain.market.BookTicker;
 import com.binance.api.client.domain.market.Candlestick;
@@ -47,6 +48,9 @@ public interface BinanceApiService {
   @GET("/api/v1/exchangeInfo")
   Call<ExchangeInfo> getExchangeInfo();
 
+  @GET("/assetWithdraw/getAllAsset.html")
+  Call<AllAssets> getAllAssets();
+
   // Market data endpoints
 
   @GET("/api/v1/depth")
@@ -69,13 +73,13 @@ public interface BinanceApiService {
 
   @GET("/api/v1/ticker/24hr")
   Call<TickerStatistics> get24HrPriceStatistics(@Query("symbol") String symbol);
-  
+
   @GET("/api/v1/ticker/24hr")
   Call<List<TickerStatistics>> getAll24HrPriceStatistics();
 
   @GET("/api/v1/ticker/allPrices")
   Call<List<TickerPrice>> getLatestPrices();
-  
+
   @GET("/api/v3/ticker/price")
   Call<TickerPrice> getLatestPrice(@Query("symbol") String symbol);
 


### PR DESCRIPTION
Although not a part of the official API, the getAllAsset page on
Binance’s website is useful for determining whether an asset can be
withdrawn.