### PR TITLE
Support newOrderRespType and fix onFailure routing in BinanceApiCallbackAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ System.out.println(order.getExecutedQty());
 
 #### Placing a MARKET order
 ```java
-NewOrderResponse newOrderResponse = client.newOrder(marketBuy("LINKETH", "1000"));
+NewOrderResponse newOrderResponse = client.newOrder(marketBuy("LINKETH", "1000").orderRespType(OrderResponseType.FULL));
+List<Trade> fills = newOrderResponse.getFills();
 System.out.println(newOrderResponse.getClientOrderId());
 ```
 <details>

--- a/src/main/java/com/binance/api/client/domain/account/NewOrder.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrder.java
@@ -57,6 +57,11 @@ public class NewOrder {
   private String icebergQty;
 
   /**
+   * Set the response JSON. ACK, RESULT, or FULL; default: RESULT.
+   */
+  private NewOrderResponseType newOrderRespType;
+
+  /**
    * Receiving window.
    */
   private Long recvWindow;
@@ -75,6 +80,7 @@ public class NewOrder {
     this.type = type;
     this.timeInForce = timeInForce;
     this.quantity = quantity;
+    this.newOrderRespType = NewOrderResponseType.RESULT;
     this.timestamp = System.currentTimeMillis();
     this.recvWindow = BinanceApiConstants.DEFAULT_RECEIVING_WINDOW;
   }
@@ -168,6 +174,15 @@ public class NewOrder {
     return this;
   }
 
+  public NewOrderResponseType getNewOrderRespType() {
+    return newOrderRespType;
+  }
+
+  public NewOrder newOrderRespType(NewOrderResponseType newOrderRespType) {
+    this.newOrderRespType = newOrderRespType;
+    return this;
+  }
+
   public Long getRecvWindow() {
     return recvWindow;
   }
@@ -234,6 +249,7 @@ public class NewOrder {
         .append("newClientOrderId", newClientOrderId)
         .append("stopPrice", stopPrice)
         .append("icebergQty", icebergQty)
+        .append("newOrderRespType", newOrderRespType)
         .append("recvWindow", recvWindow)
         .append("timestamp", timestamp)
         .toString();

--- a/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
@@ -1,8 +1,15 @@
 package com.binance.api.client.domain.account;
 
 import com.binance.api.client.constant.BinanceApiConstants;
+import com.binance.api.client.domain.OrderSide;
+import com.binance.api.client.domain.OrderStatus;
+import com.binance.api.client.domain.OrderType;
+import com.binance.api.client.domain.TimeInForce;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Response returned when placing a new order on the system.
@@ -27,6 +34,20 @@ public class NewOrderResponse {
    * which was passed when creating the new order.
    */
   private String clientOrderId;
+
+  private String price;
+
+  private String executedQty;
+
+  private OrderStatus status;
+
+  private TimeInForce timeInForce;
+
+  private OrderType type;
+
+  private OrderSide side;
+
+  private List<Trade> fills;
 
   /**
    * Transact time for this order.
@@ -65,6 +86,62 @@ public class NewOrderResponse {
     this.transactTime = transactTime;
   }
 
+  public String getPrice() {
+    return price;
+  }
+
+  public void setPrice(String price) {
+    this.price = price;
+  }
+
+  public String getExecutedQty() {
+    return executedQty;
+  }
+
+  public void setExecutedQty(String executedQty) {
+    this.executedQty = executedQty;
+  }
+
+  public OrderStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(OrderStatus status) {
+    this.status = status;
+  }
+
+  public TimeInForce getTimeInForce() {
+    return timeInForce;
+  }
+
+  public void setTimeInForce(TimeInForce timeInForce) {
+    this.timeInForce = timeInForce;
+  }
+
+  public OrderType getType() {
+    return type;
+  }
+
+  public void setType(OrderType type) {
+    this.type = type;
+  }
+
+  public OrderSide getSide() {
+    return side;
+  }
+
+  public void setSide(OrderSide side) {
+    this.side = side;
+  }
+
+  public List<Trade> getFills() {
+    return fills;
+  }
+
+  public void setFills(List<Trade> fills) {
+    this.fills = fills;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE)
@@ -72,6 +149,13 @@ public class NewOrderResponse {
         .append("orderId", orderId)
         .append("clientOrderId", clientOrderId)
         .append("transactTime", transactTime)
+        .append("price", price)
+        .append("executedQty", executedQty)
+        .append("status", status)
+        .append("timeInForce", timeInForce)
+        .append("type", type)
+        .append("side", side)
+        .append("fills", fills.stream().map(Object::toString).collect(Collectors.joining(", ")))
         .toString();
   }
 }

--- a/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
@@ -37,6 +37,8 @@ public class NewOrderResponse {
 
   private String price;
 
+  private String origQty;
+
   private String executedQty;
 
   private OrderStatus status;
@@ -92,6 +94,14 @@ public class NewOrderResponse {
 
   public void setPrice(String price) {
     this.price = price;
+  }
+
+  public String getOrigQty() {
+    return origQty;
+  }
+
+  public void setOrigQty(String origQty) {
+    this.origQty = origQty;
   }
 
   public String getExecutedQty() {
@@ -150,6 +160,7 @@ public class NewOrderResponse {
         .append("clientOrderId", clientOrderId)
         .append("transactTime", transactTime)
         .append("price", price)
+        .append("origQty", origQty)
         .append("executedQty", executedQty)
         .append("status", status)
         .append("timeInForce", timeInForce)

--- a/src/main/java/com/binance/api/client/domain/account/NewOrderResponseType.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrderResponseType.java
@@ -1,0 +1,12 @@
+package com.binance.api.client.domain.account;
+
+/**
+ * Desired response type of NewOrder requests.
+ * @see NewOrderResponse
+ */
+public enum NewOrderResponseType {
+    ACK,
+    RESULT,
+    FULL
+}
+

--- a/src/main/java/com/binance/api/client/domain/account/Trade.java
+++ b/src/main/java/com/binance/api/client/domain/account/Trade.java
@@ -2,6 +2,7 @@ package com.binance.api.client.domain.account;
 
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -54,8 +55,16 @@ public class Trade {
     return id;
   }
 
+  @JsonSetter("id")
   public void setId(Long id) {
     this.id = id;
+  }
+
+  @JsonSetter("tradeId")
+  public void setTradeId(Long id) {
+    if (this.id == null) {
+      setId(id);
+    }
   }
 
   public String getPrice() {

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -132,14 +132,14 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
   public void newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback) {
     binanceApiService.newOrder(order.getSymbol(), order.getSide(), order.getType(),
         order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-        order.getIcebergQty(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+        order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
   public void newOrderTest(NewOrder order, BinanceApiCallback<Void> callback) {
     binanceApiService.newOrderTest(order.getSymbol(), order.getSide(), order.getType(),
         order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-        order.getIcebergQty(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+        order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   // Account endpoints

--- a/src/main/java/com/binance/api/client/impl/BinanceApiCallbackAdapter.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiCallbackAdapter.java
@@ -33,15 +33,19 @@ public class BinanceApiCallbackAdapter<T> implements Callback<T> {
       }
       try {
         BinanceApiError apiError = getBinanceApiError(response);
-        throw new BinanceApiException(apiError);
+        onFailure(call, new BinanceApiException(apiError));
       } catch (IOException e) {
-        throw new BinanceApiException(e);
+        onFailure(call, new BinanceApiException(e));
       }
     }
   }
 
   @Override
   public void onFailure(Call<T> call, Throwable throwable) {
-    throw new BinanceApiException(throwable);
+    if (throwable instanceof BinanceApiException) {
+      callback.onFailure(throwable);
+    } else {
+      callback.onFailure(new BinanceApiException(throwable));
+    }
   }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -129,14 +129,14 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
   public NewOrderResponse newOrder(NewOrder order) {
     return executeSync(binanceApiService.newOrder(order.getSymbol(), order.getSide(), order.getType(),
         order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-        order.getIcebergQty(), order.getRecvWindow(), order.getTimestamp()));
+        order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()));
   }
 
   @Override
   public void newOrderTest(NewOrder order) {
     executeSync(binanceApiService.newOrderTest(order.getSymbol(), order.getSide(), order.getType(),
         order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-        order.getIcebergQty(), order.getRecvWindow(), order.getTimestamp()));
+        order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()));
   }
 
   // Account endpoints

--- a/src/main/java/com/binance/api/client/impl/BinanceApiService.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiService.java
@@ -8,6 +8,7 @@ import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.DepositAddress;
 import com.binance.api.client.domain.account.DepositHistory;
 import com.binance.api.client.domain.account.NewOrderResponse;
+import com.binance.api.client.domain.account.NewOrderResponseType;
 import com.binance.api.client.domain.account.Order;
 import com.binance.api.client.domain.account.Trade;
 import com.binance.api.client.domain.account.TradeHistoryItem;
@@ -94,14 +95,16 @@ public interface BinanceApiService {
   Call<NewOrderResponse> newOrder(@Query("symbol") String symbol, @Query("side") OrderSide side, @Query("type") OrderType type,
                                   @Query("timeInForce") TimeInForce timeInForce, @Query("quantity") String quantity, @Query("price") String price,
                                   @Query("newClientOrderId") String newClientOrderId, @Query("stopPrice") String stopPrice,
-                                  @Query("icebergQty") String icebergQty, @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
+                                  @Query("icebergQty") String icebergQty, @Query("newOrderRespType") NewOrderResponseType newOrderRespType,
+                                  @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
   @POST("/api/v3/order/test")
   Call<Void> newOrderTest(@Query("symbol") String symbol, @Query("side") OrderSide side, @Query("type") OrderType type,
                           @Query("timeInForce") TimeInForce timeInForce, @Query("quantity") String quantity, @Query("price") String price,
                           @Query("newClientOrderId") String newClientOrderId, @Query("stopPrice") String stopPrice,
-                          @Query("icebergQty") String icebergQty, @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
+                          @Query("icebergQty") String icebergQty, @Query("newOrderRespType") NewOrderResponseType newOrderRespType,
+                          @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
   @GET("/api/v3/order")

--- a/src/test/java/com/binance/api/examples/OrdersExample.java
+++ b/src/test/java/com/binance/api/examples/OrdersExample.java
@@ -4,6 +4,7 @@ import com.binance.api.client.BinanceApiClientFactory;
 import com.binance.api.client.BinanceApiRestClient;
 import com.binance.api.client.domain.TimeInForce;
 import com.binance.api.client.domain.account.NewOrderResponse;
+import com.binance.api.client.domain.account.NewOrderResponseType;
 import com.binance.api.client.domain.account.Order;
 import com.binance.api.client.domain.account.request.AllOrdersRequest;
 import com.binance.api.client.domain.account.request.CancelOrderRequest;
@@ -51,7 +52,7 @@ public class OrdersExample {
     client.newOrderTest(marketBuy("LINKETH", "1000"));
 
     // Placing a real LIMIT order
-    NewOrderResponse newOrderResponse = client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001"));
+    NewOrderResponse newOrderResponse = client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001").newOrderRespType(NewOrderResponseType.FULL));
     System.out.println(newOrderResponse);
   }
 


### PR DESCRIPTION
Thanks for this library! I'm currently using it in my Scala project and I want to share some improvements.

Binance added [`newOrderRespType`](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-order--trade) on their V3 API, allowing API clients to specify the desired response format by choosing between `ACK`/`RESULT`/`FULL`. `FULL` makes Binance return full details on the newly created order, including `executedQty` and `fills`, which in turn contain `price`, `qty` and `commission`. This enables you to **calculate the (average) fill price for market orders**. (fixes #105)

`binance-java-api` did not support this functionality yet. I also added error routing to `BinanceApiCallbackAdapter`, which previously threw any exceptions rather than calling `onFailure` of the wrapped `BinanceApiCallback`. Now you can actually catch exceptions when using the async API.