### PR TITLE
disable fail on unknown fields when retrieving open orders

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -24,7 +24,10 @@ public class BinanceApiServiceGenerator {
     private static Retrofit.Builder builder =
         new Retrofit.Builder()
             .baseUrl(BinanceApiConstants.API_BASE_URL)
-            .addConverterFactory(JacksonConverterFactory.create());
+            .addConverterFactory(JacksonConverterFactory.create(
+                            new ObjectMapper()
+                                    .disable(FAIL_ON_UNKNOWN_PROPERTIES)
+                    ));
 
     private static Retrofit retrofit = builder.build();
 


### PR DESCRIPTION
hot fix for this issue https://github.com/binance-exchange/binance-java-api/issues/143