### PR TITLE
Allow multiple accounts to coexist

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -35,11 +35,10 @@ public class BinanceApiServiceGenerator {
     public static <S> S createService(Class<S> serviceClass, String apiKey, String secret) {
         if (!StringUtils.isEmpty(apiKey) && !StringUtils.isEmpty(secret)) {
             AuthenticationInterceptor interceptor = new AuthenticationInterceptor(apiKey, secret);
-            if (!httpClient.interceptors().contains(interceptor)) {
-                httpClient.addInterceptor(interceptor);
-                builder.client(httpClient.build());
-                retrofit = builder.build();
-            }
+            httpClient.interceptors().clear();
+            httpClient.addInterceptor(interceptor);
+            builder.client(httpClient.build());
+            retrofit = builder.build();
         }
         return retrofit.create(serviceClass);
     }


### PR DESCRIPTION
As I tried to work with multiple Binance accounts, I noticed, with the code following :

```
public static void main(String[] args) {
	  
	try {
	    BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("0000", "0000");
	    BinanceApiRestClient client = factory.newRestClient();

	    // Get account balances
	    Account account = client.getAccount(6000000L, System.currentTimeMillis());
	    System.out.println(account.getAssetBalance("VEN"));
	} catch(BinanceApiException e) {
		e.printStackTrace();
	}
    
	try {
	    BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("VALID API KEY", "VALID SECRET KEY");
	    BinanceApiRestClient client = factory.newRestClient();

	    // Get account balances
	    Account account = client.getAccount(6000000L, System.currentTimeMillis());
	    System.out.println(account.getAssetBalance("VEN"));
	} catch(BinanceApiException e) {
		e.printStackTrace();
	}
  }
```

* **Situtation 1 : First account valid, second account incorrect**
Both requests returns informations from the first, valid, account
The second account is considered as valid (call.execute() line 53 in BinanceApiServiceGenerator returns true for both cases)

* **Situation 2 : First account incorrect, second account valid**
Behaves as intended, the first one throws an exception, the second one returns the balance present on the account

* **Situation 3 : Both accounts valid but from different Binance accounts**
_Not tested_

The modifications I propose allows the above code to detect an invalid account no matter the order its called.

I tried to read and understand the code as much as I could but I might have done something wrong, in this case I'm curious to know what and why.

Hope I'll hear news from you.