### PR TITLE
Stop the NPE in `NewOrderResponse`s `toString` method if fills is null.

### DIFF
--- a/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
+++ b/src/main/java/com/binance/api/client/domain/account/NewOrderResponse.java
@@ -6,6 +6,7 @@ import com.binance.api.client.domain.OrderStatus;
 import com.binance.api.client.domain.OrderType;
 import com.binance.api.client.domain.TimeInForce;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.List;
@@ -51,7 +52,7 @@ public class NewOrderResponse {
 
   private OrderSide side;
 
-  private List<Trade> fills;
+  private List<Trade> fills = Collections.emptyList();
 
   /**
    * Transact time for this order.
@@ -159,24 +160,33 @@ public class NewOrderResponse {
   }
 
   public void setFills(List<Trade> fills) {
-    this.fills = fills;
+    if (fills == null) {
+      this.fills = Collections.emptyList();
+    } else {
+      this.fills = fills;
+    }
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE)
-        .append("symbol", symbol)
-        .append("orderId", orderId)
-        .append("clientOrderId", clientOrderId)
-        .append("transactTime", transactTime)
-        .append("price", price)
-        .append("origQty", origQty)
-        .append("executedQty", executedQty)
-        .append("status", status)
-        .append("timeInForce", timeInForce)
-        .append("type", type)
-        .append("side", side)
-        .append("fills", fills.stream().map(Object::toString).collect(Collectors.joining(", ")))
-        .toString();
+    final String fillsString = fills.stream()
+        .map(Object::toString)
+        .collect(Collectors.joining(", ", "[", "]"));
+
+    return "NewOrderResponse{" +
+        "symbol='" + symbol + '\'' +
+        ", orderId=" + orderId +
+        ", clientOrderId='" + clientOrderId + '\'' +
+        ", price='" + price + '\'' +
+        ", origQty='" + origQty + '\'' +
+        ", executedQty='" + executedQty + '\'' +
+        ", cummulativeQuoteQty='" + cummulativeQuoteQty + '\'' +
+        ", status=" + status +
+        ", timeInForce=" + timeInForce +
+        ", type=" + type +
+        ", side=" + side +
+        ", transactTime=" + transactTime +
+        ", fills=" + fillsString +
+        '}';
   }
 }

--- a/src/test/java/com/binance/api/client/domain/account/NewOrderResponseTest.java
+++ b/src/test/java/com/binance/api/client/domain/account/NewOrderResponseTest.java
@@ -1,0 +1,70 @@
+package com.binance.api.client.domain.account;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NewOrderResponseTest {
+
+  private NewOrderResponse response;
+  private Trade someTrade;
+
+  @Before
+  public void setUp() {
+    response = new NewOrderResponse();
+
+    someTrade = new Trade();
+    someTrade.setId(123L);
+  }
+
+  @Test
+  public void shouldDefaultToNoFills() {
+    assertThat(response.getFills().size(), is(0));
+  }
+
+  @Test
+  public void shouldClearAnyFillsIfSetToZero() {
+    // Given:
+    response.setFills(trades(someTrade));
+
+    // When:
+    response.setFills(null);
+
+    // Then:
+    assertThat(response.getFills().size(), is(0));
+  }
+
+  @Test
+  public void shouldHandleToStringWithNullFills() {
+    assertThat(response.toString(), containsString(", fills=[]"));
+  }
+
+  @Test
+  public void shouldHandleToStringWithNoFills() {
+    // Given:
+    response.setFills(Collections.emptyList());
+
+    // Then:
+    assertThat(response.toString(), containsString(", fills=[]"));
+  }
+
+  @Test
+  public void shouldHandleToStringWithFills() {
+    // Given:
+    response.setFills(trades(someTrade));
+
+    // Then:
+    assertThat(response.toString(), containsString(", fills=[Trade[id=123,"));
+  }
+
+  private static List<Trade> trades(final Trade... trades) {
+    return Arrays.asList(trades);
+  }
+}


### PR DESCRIPTION
Fixes  #173

I've changed NewOrderResponse to be a little smarter. It now never returns null from `getFills` or throws an NPE from `toString`.