### PR TITLE
multi-channel subscription on single websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ client.closeUserDataStream(listenKey);
 BinanceApiWebSocketClient client = BinanceApiClientFactory.newInstance().newWebSocketClient();
 ```
 
+User needs to be aware that REST symbols which are `upper case` differ from WebSocket symbols which must be `lower case`.
+In scenario of subscription with upper case styled symbol, server will return no error and subscribe to given channel - however, no events will be pushed.   
+
 #### Handling web socket errors
 
 Each of the methods on `BinanceApiWebSocketClient`, which opens a new web socket, takes a `BinanceApiCallback`, which is
@@ -430,6 +433,37 @@ client.onUserDataUpdateEvent(listenKey, response -> {
   }
 });
 ```
+
+#### Multi-channel subscription
+Client provides a way for user to subscribe to multiple channels using same websocket - to achieve that user needs to coma-separate symbols as it is in following examples.
+
+````java
+client.onAggTradeEvent("ethbtc,ethusdt", (AggTradeEvent response) -> {
+  if (Objects.equals(response.getSymbol(),"ethbtc")) {
+      // handle ethbtc event
+  } else if(Objects.equals(response.getSymbol()),"ethusdt")) {
+      // handle ethusdt event
+  }
+});
+````
+````java
+client.onDepthEvent("ethbtc,ethusdt", (DepthEvent response) -> {
+  if (Objects.equals(response.getSymbol(),"ethbtc")) {
+      // handle ethbtc event
+  } else if(Objects.equals(response.getSymbol()),"ethusdt")) {
+      // handle ethusdt event
+  }
+});
+````
+````java
+client.onCandlestickEvent("ethbtc,ethusdt", CandlestickInterval.ONE_MINUTE, (CandlestickEvent response) -> {
+  if (Objects.equals(response.getSymbol(),"ethbtc")) {
+      // handle ethbtc event
+  } else if(Objects.equals(response.getSymbol()),"ethusdt")) {
+      // handle ethusdt event
+  }
+});
+````
 
 ### Asynchronous requests
 

--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -18,30 +18,30 @@ public interface BinanceApiWebSocketClient extends Closeable {
     /**
      * Open a new web socket to receive {@link DepthEvent depthEvents} on a callback.
      *
-     * @param symbol   the market symbol to subscribe to
-     * @param callback the callback to call on new events
+     * @param symbols   market (one or coma-separated) symbol(s) to subscribe to
+     * @param callback  the callback to call on new events
      * @return a {@link Closeable} that allows the underlying web socket to be closed.
      */
-    Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback);
+    Closeable onDepthEvent(String symbols, BinanceApiCallback<DepthEvent> callback);
 
     /**
      * Open a new web socket to receive {@link CandlestickEvent candlestickEvents} on a callback.
      *
-     * @param symbol   the market symbol to subscribe to
-     * @param interval the interval of the candles tick events required
-     * @param callback the callback to call on new events
+     * @param symbols   market (one or coma-separated) symbol(s) to subscribe to
+     * @param interval  the interval of the candles tick events required
+     * @param callback  the callback to call on new events
      * @return a {@link Closeable} that allows the underlying web socket to be closed.
      */
-    Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
+    Closeable onCandlestickEvent(String symbols, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback);
 
     /**
      * Open a new web socket to receive {@link AggTradeEvent aggTradeEvents} on a callback.
      *
-     * @param symbol   the market symbol to subscribe to
-     * @param callback the callback to call on new events
+     * @param symbols   market (one or coma-separated) symbol(s) to subscribe to
+     * @param callback  the callback to call on new events
      * @return a {@link Closeable} that allows the underlying web socket to be closed.
      */
-    Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback);
+    Closeable onAggTradeEvent(String symbols, BinanceApiCallback<AggTradeEvent> callback);
 
     /**
      * Open a new web socket to receive {@link UserDataUpdateEvent userDataUpdateEvents} on a callback.

--- a/src/main/java/com/binance/api/client/domain/event/OrderTradeUpdateEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/OrderTradeUpdateEvent.java
@@ -25,7 +25,7 @@ public class OrderTradeUpdateEvent {
   private String eventType;
 
   @JsonProperty("E")
-  private long eventTime;
+  private Long eventTime;
 
   @JsonProperty("s")
   private String symbol;
@@ -137,11 +137,11 @@ public class OrderTradeUpdateEvent {
     this.eventType = eventType;
   }
 
-  public long getEventTime() {
+  public Long getEventTime() {
     return eventTime;
   }
 
-  public void setEventTime(long eventTime) {
+  public void setEventTime(Long eventTime) {
     this.eventTime = eventTime;
   }
 
@@ -225,7 +225,7 @@ public class OrderTradeUpdateEvent {
     this.orderRejectReason = orderRejectReason;
   }
 
-  public long getOrderId() {
+  public Long getOrderId() {
     return orderId;
   }
 
@@ -273,19 +273,19 @@ public class OrderTradeUpdateEvent {
     this.commissionAsset = commissionAsset;
   }
 
-  public long getOrderTradeTime() {
+  public Long getOrderTradeTime() {
     return orderTradeTime;
   }
 
-  public void setOrderTradeTime(long orderTradeTime) {
+  public void setOrderTradeTime(Long orderTradeTime) {
     this.orderTradeTime = orderTradeTime;
   }
 
-  public long getTradeId() {
+  public Long getTradeId() {
     return tradeId;
   }
 
-  public void setTradeId(long tradeId) {
+  public void setTradeId(Long tradeId) {
     this.tradeId = tradeId;
   }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -15,14 +15,16 @@ import okhttp3.Request;
 import okhttp3.WebSocket;
 
 import java.io.Closeable;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Binance API WebSocket client implementation using OkHttp.
  */
 public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient, Closeable {
 
-    private OkHttpClient client;
+    private final OkHttpClient client;
 
     public BinanceApiWebSocketClientImpl() {
         Dispatcher d = new Dispatcher();
@@ -30,19 +32,29 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
         this.client = new OkHttpClient.Builder().dispatcher(d).build();
     }
 
-    public Closeable onDepthEvent(String symbol, BinanceApiCallback<DepthEvent> callback) {
-        final String channel = String.format("%s@depth", symbol);
+    @Override
+    public Closeable onDepthEvent(String symbols, BinanceApiCallback<DepthEvent> callback) {
+        final String channel = Arrays.stream(symbols.split(","))
+                .map(String::trim)
+                .map(s -> String.format("%s@depth", s))
+                .collect(Collectors.joining("/"));
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, DepthEvent.class));
     }
 
     @Override
-    public Closeable onCandlestickEvent(String symbol, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
-        final String channel = String.format("%s@kline_%s", symbol, interval.getIntervalId());
+    public Closeable onCandlestickEvent(String symbols, CandlestickInterval interval, BinanceApiCallback<CandlestickEvent> callback) {
+        final String channel = Arrays.stream(symbols.split(","))
+                .map(String::trim)
+                .map(s -> String.format("%s@kline_%s", s, interval.getIntervalId()))
+                .collect(Collectors.joining("/"));
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, CandlestickEvent.class));
     }
 
-    public Closeable onAggTradeEvent(String symbol, BinanceApiCallback<AggTradeEvent> callback) {
-        final String channel = String.format("%s@aggTrade", symbol);
+    public Closeable onAggTradeEvent(String symbols, BinanceApiCallback<AggTradeEvent> callback) {
+        final String channel = Arrays.stream(symbols.split(","))
+                .map(String::trim)
+                .map(s -> String.format("%s@aggTrade", s))
+                .collect(Collectors.joining("/"));
         return createNewWebSocket(channel, new BinanceApiWebSocketListener<>(callback, AggTradeEvent.class));
     }
 

--- a/src/test/java/com/binance/api/domain/event/UserDataUpdateEventDeserializerTest.java
+++ b/src/test/java/com/binance/api/domain/event/UserDataUpdateEventDeserializerTest.java
@@ -70,8 +70,8 @@ public class UserDataUpdateEventDeserializerTest {
       assertEquals(orderTradeUpdateEvent.getOrderStatus(), OrderStatus.CANCELED);
       assertEquals(orderTradeUpdateEvent.getOrderRejectReason(), OrderRejectReason.NONE);
 
-      assertEquals(orderTradeUpdateEvent.getOrderId(), 123456L);
-      assertEquals(orderTradeUpdateEvent.getOrderTradeTime(), 1L);
+      assertEquals(orderTradeUpdateEvent.getOrderId(), new Long(123456));
+      assertEquals(orderTradeUpdateEvent.getOrderTradeTime(), new Long(1));
     } catch (IOException e) {
       fail();
     }


### PR DESCRIPTION
This PR enables multi-symbol subscription per single (physical) websocket.
However, implementation does not permit cross-channel subscribing for the sake of backward compability.

Scope of PR:
- java code
- README.md documenting the changes (and reference on upper/lower case symbol difference between WS and REST so future API users don't go loco)

/ Miron