### PR TITLE
custom dispatcher for sharedClient to allow for more parallel requests

### DIFF
--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -4,6 +4,7 @@ import com.binance.api.client.BinanceApiError;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.exception.BinanceApiException;
 import com.binance.api.client.security.AuthenticationInterceptor;
+import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -22,11 +23,19 @@ import java.util.concurrent.TimeUnit;
  * Generates a Binance API implementation based on @see {@link BinanceApiService}.
  */
 public class BinanceApiServiceGenerator {
-    private static final OkHttpClient sharedClient = new OkHttpClient.Builder()
-            .pingInterval(20, TimeUnit.SECONDS)
-            .build();
 
+    private static final OkHttpClient sharedClient;
     private static final Converter.Factory converterFactory = JacksonConverterFactory.create();
+
+    static {
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequestsPerHost(500);
+        dispatcher.setMaxRequests(500);
+        sharedClient = new OkHttpClient.Builder()
+                .dispatcher(dispatcher)
+                .pingInterval(20, TimeUnit.SECONDS)
+                .build();
+    }
 
     @SuppressWarnings("unchecked")
     private static final Converter<ResponseBody, BinanceApiError> errorBodyConverter =


### PR DESCRIPTION
Since commit https://github.com/binance-exchange/binance-java-api/pull/133/commits/bed23c0e95d0c009bbf36486a4259420856f593c
there is only one application wide shared HTTP client instance. 

Because of the fact that no custom dispatcher for this client is configured, the following [default request limits](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/Dispatcher.java#L40-L41) apply to the whole application:
```
  private int maxRequests = 64;
  private int maxRequestsPerHost = 5;
```
These limits are far to little when running a bigger trading application which retrieves updates for many symbols in parallel. 

To solve this issue I introduced a customized dispatcher with maxRequests and maxRequestsPerHost of 500.