### PR TITLE
Add license to POM for license-maven-plugin compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
   <groupId>com.binance.api</groupId>
   <artifactId>binance-api-client</artifactId>
   <version>1.0.0</version>
+  <licenses>
+    <license>
+      <name>The MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
 
   <properties>
     <com.squareup.retrofit2.version>2.4.0</com.squareup.retrofit2.version>


### PR DESCRIPTION
License metadata is useful for
http://www.mojohaus.org/license-maven-plugin/ interoperability as well
as a requirement of eventual listing in Maven Central (OSSHR) as per
https://central.sonatype.org/pages/requirements.html.