### PR TITLE
Add Cummulative Quote Quantity

### DIFF
--- a/src/main/java/com/binance/api/client/domain/account/Order.java
+++ b/src/main/java/com/binance/api/client/domain/account/Order.java
@@ -78,6 +78,11 @@ public class Order {
    * Order timestamp.
    */
   private long time;
+  
+  /**
+  * Used to calculate the average price 
+  */
+  private String cummulativeQuoteQty;
 
   public String getSymbol() {
     return symbol;
@@ -182,6 +187,14 @@ public class Order {
   public void setTime(long time) {
     this.time = time;
   }
+  
+  public String getCummulativeQuoteQty() {
+    return cummulativeQuoteQty;
+  }
+
+  public void setCummulativeQuoteQty(String cummulativeQuoteQty) {
+     this.cummulativeQuoteQty = cummulativeQuoteQty;
+  }
 
   @Override
   public String toString() {
@@ -199,6 +212,7 @@ public class Order {
         .append("stopPrice", stopPrice)
         .append("icebergQty", icebergQty)
         .append("time", time)
+        .append("cummulativeQuoteQty", cummulativeQuoteQty)
         .toString();
   }
 }


### PR DESCRIPTION
`cummulativeQuoteQty` is needed to calculate the average price, for example when using market order

Reference: https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#query-order-user_data