### PR TITLE
Update Binance endpoints to non-deprecated versions

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiAsyncRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiAsyncRestClient.java
@@ -145,26 +145,20 @@ public interface BinanceApiAsyncRestClient {
    void getAll24HrPriceStatistics(BinanceApiCallback<List<TickerStatistics>> callback);
 
   /**
-   * Get Latest price for all symbols (asynchronous).
-   *
-   * @param callback the callback that handles the response
-   */
-  void getAllPrices(BinanceApiCallback<List<TickerPrice>> callback);
-  
-  /**
    * Get latest price for <code>symbol</code> (asynchronous).
    * 
    * @param symbol ticker symbol (e.g. ETHBTC)
    * @param callback the callback that handles the response
    */
-   void getPrice(String symbol , BinanceApiCallback<TickerPrice> callback);
+   void getPrice(String symbol, BinanceApiCallback<TickerPrice> callback);
 
   /**
-   * Get best price/qty on the order book for all symbols (asynchronous).
+   * Get best price/qty on the order book for <code>symbol</code> (asynchronous).
    *
+   * @param symbol ticker symbol (e.g. ETHBTC)
    * @param callback the callback that handles the response
    */
-  void getBookTickers(BinanceApiCallback<List<BookTicker>> callback);
+  void getBookTicker(String symbol, BinanceApiCallback<BookTicker> callback);
 
   // Account endpoints
 

--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -138,11 +138,6 @@ public interface BinanceApiRestClient {
   List<TickerStatistics> getAll24HrPriceStatistics();
 
   /**
-   * Get Latest price for all symbols.
-   */
-  List<TickerPrice> getAllPrices();
-
-  /**
    * Get latest price for <code>symbol</code>.
    *
    * @param symbol ticker symbol (e.g. ETHBTC)
@@ -150,9 +145,9 @@ public interface BinanceApiRestClient {
   TickerPrice getPrice(String symbol);
 
   /**
-   * Get best price/qty on the order book for all symbols.
+   * Get best price/qty on the order book for <code>symbol</code>.
    */
-  List<BookTicker> getBookTickers();
+  BookTicker getBookTicker(String symbol);
 
   // Account endpoints
 

--- a/src/main/java/com/binance/api/client/domain/account/TradeHistoryItem.java
+++ b/src/main/java/com/binance/api/client/domain/account/TradeHistoryItem.java
@@ -26,6 +26,11 @@ public class TradeHistoryItem {
     private String qty;
 
     /**
+     * Quote quantity.
+     */
+    private String quoteQty;
+
+    /**
      * Trade execution time.
      */
     private long time;
@@ -66,6 +71,14 @@ public class TradeHistoryItem {
         this.qty = qty;
     }
 
+    public String getQuoteQty() {
+        return quoteQty;
+    }
+
+    public void setQuoteQty(String quoteQty) {
+        this.quoteQty = quoteQty;
+    }
+
     public long getTime() {
         return time;
     }
@@ -96,6 +109,7 @@ public class TradeHistoryItem {
             .append("id", id)
             .append("price", price)
             .append("qty", qty)
+            .append("quoteQty", quoteQty)
             .append("time", time)
             .append("isBuyerMaker", isBuyerMaker)
             .append("isBestMatch", isBestMatch)

--- a/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
+++ b/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
@@ -8,5 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public enum RateLimitType {
   REQUEST_WEIGHT,
-  ORDERS
+  ORDERS,
+  RAW_REQUESTS
 }

--- a/src/main/java/com/binance/api/client/domain/general/SymbolInfo.java
+++ b/src/main/java/com/binance/api/client/domain/general/SymbolInfo.java
@@ -29,6 +29,12 @@ public class SymbolInfo {
 
   private boolean icebergAllowed;
 
+  private boolean ocoAllowed;
+
+  private boolean isSpotTradingAllowed;
+
+  private boolean isMarginTradingAllowed;
+
   private List<SymbolFilter> filters;
 
   public String getSymbol() {
@@ -91,6 +97,18 @@ public class SymbolInfo {
     return icebergAllowed;
   }
 
+  public boolean isOcoAllowed() {
+    return ocoAllowed;
+  }
+
+  public boolean isSpotTradingAllowed() {
+    return isSpotTradingAllowed;
+  }
+
+  public boolean isMarginTradingAllowed() {
+    return isMarginTradingAllowed;
+  }
+
   public void setIcebergAllowed(boolean icebergAllowed) {
     this.icebergAllowed = icebergAllowed;
   }
@@ -125,6 +143,9 @@ public class SymbolInfo {
         .append("quotePrecision", quotePrecision)
         .append("orderTypes", orderTypes)
         .append("icebergAllowed", icebergAllowed)
+        .append("ocoAllowed", ocoAllowed)
+        .append("isSpotTradingAllowed", isSpotTradingAllowed)
+        .append("isMarginTradingAllowed", isMarginTradingAllowed)
         .append("filters", filters)
         .toString();
   }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -116,18 +116,13 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
   }
 
   @Override
-  public void getAllPrices(BinanceApiCallback<List<TickerPrice>> callback) {
-    binanceApiService.getLatestPrices().enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
-
-  @Override
-  public void getPrice(String symbol , BinanceApiCallback<TickerPrice> callback) {
+  public void getPrice(String symbol, BinanceApiCallback<TickerPrice> callback) {
     binanceApiService.getLatestPrice(symbol).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override
-  public void getBookTickers(BinanceApiCallback<List<BookTicker>> callback) {
-    binanceApiService.getBookTickers().enqueue(new BinanceApiCallbackAdapter<>(callback));
+  public void getBookTicker(String symbol, BinanceApiCallback<BookTicker> callback) {
+    binanceApiService.getBookTicker(symbol).enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 
   @Override

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -118,13 +118,8 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
   }
 
   @Override
-  public List<TickerPrice> getAllPrices() {
-    return executeSync(binanceApiService.getLatestPrices());
-  }
-
-  @Override
-  public List<BookTicker> getBookTickers() {
-    return executeSync(binanceApiService.getBookTickers());
+  public BookTicker getBookTicker(String symbol) {
+    return executeSync(binanceApiService.getBookTicker(symbol));
   }
 
   @Override

--- a/src/main/java/com/binance/api/client/impl/BinanceApiService.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiService.java
@@ -43,13 +43,13 @@ public interface BinanceApiService {
 
   // General endpoints
 
-  @GET("/api/v1/ping")
+  @GET("/api/v3/ping")
   Call<Void> ping();
 
-  @GET("/api/v1/time")
+  @GET("/api/v3/time")
   Call<ServerTime> getServerTime();
 
-  @GET("/api/v1/exchangeInfo")
+  @GET("/api/v3/exchangeInfo")
   Call<ExchangeInfo> getExchangeInfo();
 
   @GET
@@ -57,38 +57,35 @@ public interface BinanceApiService {
 
   // Market data endpoints
 
-  @GET("/api/v1/depth")
+  @GET("/api/v3/depth")
   Call<OrderBook> getOrderBook(@Query("symbol") String symbol, @Query("limit") Integer limit);
 
-  @GET("/api/v1/trades")
+  @GET("/api/v3/trades")
   Call<List<TradeHistoryItem>> getTrades(@Query("symbol") String symbol, @Query("limit") Integer limit);
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_APIKEY_HEADER)
-  @GET("/api/v1/historicalTrades")
+  @GET("/api/v3/historicalTrades")
   Call<List<TradeHistoryItem>> getHistoricalTrades(@Query("symbol") String symbol, @Query("limit") Integer limit, @Query("fromId") Long fromId);
 
-  @GET("/api/v1/aggTrades")
+  @GET("/api/v3/aggTrades")
   Call<List<AggTrade>> getAggTrades(@Query("symbol") String symbol, @Query("fromId") String fromId, @Query("limit") Integer limit,
                                     @Query("startTime") Long startTime, @Query("endTime") Long endTime);
 
-  @GET("/api/v1/klines")
+  @GET("/api/v3/klines")
   Call<List<Candlestick>> getCandlestickBars(@Query("symbol") String symbol, @Query("interval") String interval, @Query("limit") Integer limit,
                                        @Query("startTime") Long startTime, @Query("endTime") Long endTime);
 
-  @GET("/api/v1/ticker/24hr")
+  @GET("/api/v3/ticker/24hr")
   Call<TickerStatistics> get24HrPriceStatistics(@Query("symbol") String symbol);
 
-  @GET("/api/v1/ticker/24hr")
+  @GET("/api/v3/ticker/24hr")
   Call<List<TickerStatistics>> getAll24HrPriceStatistics();
-
-  @GET("/api/v1/ticker/allPrices")
-  Call<List<TickerPrice>> getLatestPrices();
 
   @GET("/api/v3/ticker/price")
   Call<TickerPrice> getLatestPrice(@Query("symbol") String symbol);
 
-  @GET("/api/v1/ticker/allBookTickers")
-  Call<List<BookTicker>> getBookTickers();
+  @GET("/api/v3/ticker/bookTicker")
+  Call<BookTicker> getBookTicker(@Query("symbol") String symbol);
 
   // Account endpoints
 
@@ -159,14 +156,14 @@ public interface BinanceApiService {
   // User stream endpoints
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_APIKEY_HEADER)
-  @POST("/api/v1/userDataStream")
+  @POST("/api/v3/userDataStream")
   Call<ListenKey> startUserDataStream();
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_APIKEY_HEADER)
-  @PUT("/api/v1/userDataStream")
+  @PUT("/api/v3/userDataStream")
   Call<Void> keepAliveUserDataStream(@Query("listenKey") String listenKey);
 
   @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_APIKEY_HEADER)
-  @DELETE("/api/v1/userDataStream")
+  @DELETE("/api/v3/userDataStream")
   Call<Void> closeAliveUserDataStream(@Query("listenKey") String listenKey);
 }

--- a/src/test/java/com/binance/api/examples/MarketDataEndpointsExample.java
+++ b/src/test/java/com/binance/api/examples/MarketDataEndpointsExample.java
@@ -31,8 +31,8 @@ public class MarketDataEndpointsExample {
     System.out.println(tickerStatistics);
 
     // Getting all latest prices
-    List<TickerPrice> allPrices = client.getAllPrices();
-    System.out.println(allPrices);
+    TickerPrice price = client.getPrice("NEOETH");
+    System.out.println(price);
 
     // Getting agg trades
     List<AggTrade> aggTrades = client.getAggTrades("NEOETH");
@@ -43,8 +43,8 @@ public class MarketDataEndpointsExample {
     System.out.println(candlesticks);
 
     // Getting all book tickers
-    List<BookTicker> allBookTickers = client.getBookTickers();
-    System.out.println(allBookTickers);
+    BookTicker bookTicker = client.getBookTicker("NEOETH");
+    System.out.println(bookTicker);
 
     // Exception handling
     try {

--- a/src/test/java/com/binance/api/examples/MarketDataEndpointsExampleAsync.java
+++ b/src/test/java/com/binance/api/examples/MarketDataEndpointsExampleAsync.java
@@ -32,7 +32,7 @@ public class MarketDataEndpointsExampleAsync {
     });
 
     // Getting all latest prices (async)
-    client.getAllPrices((List<TickerPrice> response) -> {
+    client.getPrice("NEOETH", (TickerPrice response) -> {
       System.out.println(response);
     });
 
@@ -44,7 +44,7 @@ public class MarketDataEndpointsExampleAsync {
         (List<Candlestick> response) -> System.out.println(response));
 
     // Book tickers (async)
-    client.getBookTickers(response -> System.out.println(response));
+    client.getBookTicker("NEOETH", response -> System.out.println(response));
 
     // Exception handling
     try {


### PR DESCRIPTION
As in the Change Log https://binance-docs.github.io/apidocs/spot/en/#change-log

"By end of Q1 2020, the following endpoints will be removed from the API. The documentation has been updated to use the v3 versions of these endpoints.
GET api/v1/depth
GET api/v1/historicalTrades
GET api/v1/aggTrades
GET api/v1/klines
GET api/v1/ticker/24hr
GET api/v1/ticker/price
GET api/v1/exchangeInfo
POST api/v1/userDataStream
PUT api/v1/userDataStream
GET api/v1/ping
GET api/v1/time
GET api/v1/ticker/bookTicker

These endpoints however, will NOT be migrated to v3. Please use the following endpoints instead moving forward.
Old V1 Endpoints | New V3 Endpoints
GET api/v1/ticker/allPrices | GET api/v3/ticker/price
GET api/v1/ticker/allBookTickers | GET api/v3/ticker/bookTicker"


