### PR TITLE
Allow a custom base domain name so binance.us can be used

### DIFF
--- a/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
+++ b/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
@@ -1,0 +1,57 @@
+package com.binance.api.client.config;
+
+/**
+ * Configuration used for Binance operations.
+ */
+public class BinanceApiConfig {
+
+	/**
+	 * Base domain for URLs.
+	 */
+	private static String BASE_DOMAIN = "binance.com";
+
+	/**
+	 * Default receiving window.
+	 */
+	private static long DEFAULT_RECEIVING_WINDOW = 6_000_000L;
+
+	/**
+	 * Set the URL base domain name (e.g., binance.com).
+	 *
+	 * @param baseDomain Base domain name
+	 */
+	public static void setBaseDomain(final String baseDomain) {
+		BASE_DOMAIN = baseDomain;
+	}
+
+	/**
+	 * Get the URL base domain name (e.g., binance.com).
+	 *
+	 * @return The base domain for URLs
+	 */
+	public static String getBaseDomain() {
+		return BASE_DOMAIN;
+	}
+
+	/**
+	 * REST API base URL.
+	 */
+	public static String getApiBaseUrl() {
+		return String.format("https://api.%s", getBaseDomain());
+	}
+
+	/**
+	 * Streaming API base URL.
+	 */
+	public static String getStreamApiBaseUrl() {
+		return String.format("wss://stream.%s:9443/ws", getBaseDomain());
+	}
+
+	/**
+	 * Asset info base URL.
+	 */
+	public static String getAssetInfoApiBaseUrl() {
+		return String.format("https://%s/", getBaseDomain());
+	}
+
+}

--- a/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
+++ b/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
@@ -11,11 +11,6 @@ public class BinanceApiConfig {
 	private static String BASE_DOMAIN = "binance.com";
 
 	/**
-	 * Default receiving window.
-	 */
-	private static long DEFAULT_RECEIVING_WINDOW = 6_000_000L;
-
-	/**
 	 * Set the URL base domain name (e.g., binance.com).
 	 *
 	 * @param baseDomain Base domain name

--- a/src/main/java/com/binance/api/client/constant/BinanceApiConstants.java
+++ b/src/main/java/com/binance/api/client/constant/BinanceApiConstants.java
@@ -8,21 +8,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class BinanceApiConstants {
 
   /**
-   * REST API base URL.
-   */
-  public static final String API_BASE_URL = "https://api.binance.com";
-
-  /**
-   * Streaming API base URL.
-   */
-  public static final String WS_API_BASE_URL = "wss://stream.binance.com:9443/ws";
-
-  /**
-   * Asset info base URL.
-   */
-  public static final String ASSET_INFO_API_BASE_URL = "https://www.binance.com/";
-
-  /**
    * HTTP Header to be used for API-KEY authentication.
    */
   public static final String API_KEY_HEADER = "X-MBX-APIKEY";
@@ -43,10 +28,10 @@ public class BinanceApiConstants {
    * Default receiving window.
    */
   public static final long DEFAULT_RECEIVING_WINDOW = 60_000L;
-  
+
   /**
-   * Default ToStringStyle used by toString methods. 
-   * Override this to change the output format of the overridden toString methods. 
+   * Default ToStringStyle used by toString methods.
+   * Override this to change the output format of the overridden toString methods.
    *  - Example ToStringStyle.JSON_STYLE
    */
   public static ToStringStyle TO_STRING_BUILDER_STYLE = ToStringStyle.SHORT_PREFIX_STYLE;

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -2,6 +2,7 @@ package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiAsyncRestClient;
 import com.binance.api.client.BinanceApiCallback;
+import com.binance.api.client.config.BinanceApiConfig;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.DepositAddress;
@@ -64,7 +65,7 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
 
   @Override
   public void getAllAssets(BinanceApiCallback<List<Asset>> callback) {
-    binanceApiService.getAllAssets(BinanceApiConstants.ASSET_INFO_API_BASE_URL + "assetWithdraw/getAllAsset.html")
+    binanceApiService.getAllAssets(BinanceApiConfig.getAssetInfoApiBaseUrl() + "assetWithdraw/getAllAsset.html")
         .enqueue(new BinanceApiCallbackAdapter<>(callback));
   }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -1,6 +1,7 @@
 package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiRestClient;
+import com.binance.api.client.config.BinanceApiConfig;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.account.Account;
 import com.binance.api.client.domain.account.DepositAddress;
@@ -62,7 +63,7 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
 
   @Override
   public List<Asset> getAllAssets() {
-    return executeSync(binanceApiService.getAllAssets(BinanceApiConstants.ASSET_INFO_API_BASE_URL + "assetWithdraw/getAllAsset.html"));
+    return executeSync(binanceApiService.getAllAssets(BinanceApiConfig.getAssetInfoApiBaseUrl() + "assetWithdraw/getAllAsset.html"));
   }
 
   // Market Data endpoints

--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -1,6 +1,7 @@
 package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiError;
+import com.binance.api.client.config.BinanceApiConfig;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.exception.BinanceApiException;
 import com.binance.api.client.security.AuthenticationInterceptor;
@@ -48,7 +49,7 @@ public class BinanceApiServiceGenerator {
 
     public static <S> S createService(Class<S> serviceClass, String apiKey, String secret) {
         Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
-                .baseUrl(BinanceApiConstants.API_BASE_URL)
+                .baseUrl(BinanceApiConfig.getApiBaseUrl())
                 .addConverterFactory(converterFactory);
 
         if (StringUtils.isEmpty(apiKey) || StringUtils.isEmpty(secret)) {

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -2,6 +2,7 @@ package com.binance.api.client.impl;
 
 import com.binance.api.client.BinanceApiCallback;
 import com.binance.api.client.BinanceApiWebSocketClient;
+import com.binance.api.client.config.BinanceApiConfig;
 import com.binance.api.client.constant.BinanceApiConstants;
 import com.binance.api.client.domain.event.AggTradeEvent;
 import com.binance.api.client.domain.event.AllMarketTickersEvent;
@@ -73,7 +74,7 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
     public void close() { }
 
     private Closeable createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
-        String streamingUrl = String.format("%s/%s", BinanceApiConstants.WS_API_BASE_URL, channel);
+        String streamingUrl = String.format("%s/%s", BinanceApiConfig.getStreamApiBaseUrl(), channel);
         Request request = new Request.Builder().url(streamingUrl).build();
         final WebSocket webSocket = client.newWebSocket(request, listener);
         return () -> {


### PR DESCRIPTION
This is a simple change to allow the user to override the base domain of the API URLs. I specifically restricted the changes to be a simple as possible so as to not redesign how things are configured currently.