### PR TITLE
Replace symbol `ç` to `c`

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiAsyncRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiAsyncRestClient.java
@@ -30,7 +30,7 @@ import com.binance.api.client.domain.market.TickerStatistics;
 import java.util.List;
 
 /**
- * Binance API façade, supporting asynchronous/non-blocking access Binance's REST API.
+ * Binance API facade, supporting asynchronous/non-blocking access Binance's REST API.
  */
 public interface BinanceApiAsyncRestClient {
 

--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -28,7 +28,7 @@ import com.binance.api.client.domain.market.TickerStatistics;
 import java.util.List;
 
 /**
- * Binance API façade, supporting synchronous/blocking access Binance's REST API.
+ * Binance API facade, supporting synchronous/blocking access Binance's REST API.
  */
 public interface BinanceApiRestClient {
 

--- a/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiWebSocketClient.java
@@ -11,7 +11,7 @@ import java.io.Closeable;
 import java.util.List;
 
 /**
- * Binance API data streaming façade, supporting streaming of events through web sockets.
+ * Binance API data streaming facade, supporting streaming of events through web sockets.
  */
 public interface BinanceApiWebSocketClient extends Closeable {
 


### PR DESCRIPTION
This pull request replaces symbol `ç` to `c`. Because with symbol `ç` build will crash on some linux OSes.