### PR TITLE
Allow manual closing of underlying okHttpClient connection pool

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -295,4 +295,10 @@ public interface BinanceApiRestClient {
    * @param listenKey listen key that identifies a data stream
    */
   void closeUserDataStream(String listenKey);
+  
+  /**
+   * Call to allow the client to shutdown cleanly instead of 
+   * waiting for connection timeouts.
+   */
+  void shutdown();
 }

--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -296,6 +296,7 @@ public interface BinanceApiRestClient {
    */
   void closeUserDataStream(String listenKey);
   
+  
   /**
    * Call to allow the client to shutdown cleanly instead of 
    * waiting for connection timeouts.

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -8,6 +8,8 @@ import com.binance.api.client.domain.account.request.*;
 import com.binance.api.client.domain.general.Asset;
 import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.market.*;
+
+import okhttp3.OkHttpClient;
 import retrofit2.Call;
 
 import java.util.List;
@@ -222,5 +224,13 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
   @Override
   public void closeUserDataStream(String listenKey) {
     executeSync(binanceApiService.closeAliveUserDataStream(listenKey));
+  }
+
+  
+  // Close and remove all idle connections in the pool
+  @Override
+  public void shutdown() {
+	  OkHttpClient okHttpClient = BinanceApiServiceGenerator.getSharedClient();
+	  okHttpClient.connectionPool().evictAll();
   }
 }


### PR DESCRIPTION
If there are idle okHttpClient connections a program cannot shutdown cleanly without waiting for them to timeot. This provides a way for them to be released on request and allow immediate shutdown.