### PR TITLE
Add side-effect type to the margin new order

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiAsyncMarginRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiAsyncMarginRestClient.java
@@ -41,7 +41,7 @@ public interface BinanceApiAsyncMarginRestClient {
    * @param order the new order to submit.
    * @return a response containing details about the newly placed order.
    */
-  void newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback);
+  void newOrder(MarginNewOrder order, BinanceApiCallback<MarginNewOrderResponse> callback);
 
   /**
    * Cancel an active margin order (async).

--- a/src/main/java/com/binance/api/client/BinanceApiMarginRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiMarginRestClient.java
@@ -28,7 +28,7 @@ public interface BinanceApiMarginRestClient {
      * @param order the new order to submit.
      * @return a response containing details about the newly placed order.
      */
-    NewOrderResponse newOrder(NewOrder order);
+    MarginNewOrderResponse newOrder(MarginNewOrder order);
 
     /**
      * Cancel an active margin order.

--- a/src/main/java/com/binance/api/client/domain/account/MarginNewOrder.java
+++ b/src/main/java/com/binance/api/client/domain/account/MarginNewOrder.java
@@ -1,0 +1,289 @@
+package com.binance.api.client.domain.account;
+
+import com.binance.api.client.constant.BinanceApiConstants;
+import com.binance.api.client.domain.OrderSide;
+import com.binance.api.client.domain.OrderType;
+import com.binance.api.client.domain.TimeInForce;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * A trade order to enter or exit a position.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MarginNewOrder {
+
+    /**
+     * Symbol to place the order on.
+     */
+    private String symbol;
+
+    /**
+     * Buy/Sell order side.
+     */
+    private OrderSide side;
+
+    /**
+     * Type of order.
+     */
+    private OrderType type;
+
+    /**
+     * Time in force to indicate how long will the order remain active.
+     */
+    private TimeInForce timeInForce;
+
+    /**
+     * Quantity.
+     */
+    private String quantity;
+
+    /**
+     * Quote quantity.
+     */
+    private String quoteOrderQty;
+
+    /**
+     * Price.
+     */
+    private String price;
+
+    /**
+     * A unique id for the order. Automatically generated if not sent.
+     */
+    private String newClientOrderId;
+
+    /**
+     * Used with stop orders.
+     */
+    private String stopPrice;
+
+    /**
+     * Used with iceberg orders.
+     */
+    private String icebergQty;
+
+    /**
+     * Set the response JSON. ACK, RESULT, or FULL; default: RESULT.
+     */
+    private NewOrderResponseType newOrderRespType;
+
+    /**
+     * Set the margin order side-effect. NO_SIDE_EFFECT, MARGIN_BUY, AUTO_REPAY; default: NO_SIDE_EFFECT.
+     */
+    private SideEffectType sideEffectType;
+
+    /**
+     * Receiving window.
+     */
+    private Long recvWindow;
+
+    /**
+     * Order timestamp.
+     */
+    private long timestamp;
+
+    /**
+     * Creates a new order with all required parameters.
+     */
+    public MarginNewOrder(String symbol, OrderSide side, OrderType type, TimeInForce timeInForce, String quantity) {
+        this.symbol = symbol;
+        this.side = side;
+        this.type = type;
+        this.timeInForce = timeInForce;
+        this.quantity = quantity;
+        this.newOrderRespType = NewOrderResponseType.RESULT;
+        this.timestamp = System.currentTimeMillis();
+        this.recvWindow = BinanceApiConstants.DEFAULT_RECEIVING_WINDOW;
+    }
+
+    /**
+     * Creates a new order with all required parameters plus price, which is optional for MARKET orders.
+     */
+    public MarginNewOrder(String symbol, OrderSide side, OrderType type, TimeInForce timeInForce, String quantity, String price) {
+        this(symbol, side, type, timeInForce, quantity);
+        this.price = price;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public MarginNewOrder symbol(String symbol) {
+        this.symbol = symbol;
+        return this;
+    }
+
+    public OrderSide getSide() {
+        return side;
+    }
+
+    public MarginNewOrder side(OrderSide side) {
+        this.side = side;
+        return this;
+    }
+
+    public OrderType getType() {
+        return type;
+    }
+
+    public MarginNewOrder type(OrderType type) {
+        this.type = type;
+        return this;
+    }
+
+    public TimeInForce getTimeInForce() {
+        return timeInForce;
+    }
+
+    public MarginNewOrder timeInForce(TimeInForce timeInForce) {
+        this.timeInForce = timeInForce;
+        return this;
+    }
+
+    public String getQuantity() {
+        return quantity;
+    }
+
+    public MarginNewOrder quantity(String quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    public String getQuoteOrderQty() {
+        return quoteOrderQty;
+    }
+
+    public MarginNewOrder quoteOrderQty(String quoteOrderQty) {
+        this.quoteOrderQty = quoteOrderQty;
+        return this;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public MarginNewOrder price(String price) {
+        this.price = price;
+        return this;
+    }
+
+    public String getNewClientOrderId() {
+        return newClientOrderId;
+    }
+
+    public MarginNewOrder newClientOrderId(String newClientOrderId) {
+        this.newClientOrderId = newClientOrderId;
+        return this;
+    }
+
+    public String getStopPrice() {
+        return stopPrice;
+    }
+
+    public MarginNewOrder stopPrice(String stopPrice) {
+        this.stopPrice = stopPrice;
+        return this;
+    }
+
+    public String getIcebergQty() {
+        return icebergQty;
+    }
+
+    public MarginNewOrder icebergQty(String icebergQty) {
+        this.icebergQty = icebergQty;
+        return this;
+    }
+
+    public NewOrderResponseType getNewOrderRespType() {
+        return newOrderRespType;
+    }
+
+    public MarginNewOrder newOrderRespType(NewOrderResponseType newOrderRespType) {
+        this.newOrderRespType = newOrderRespType;
+        return this;
+    }
+
+    public SideEffectType getSideEffectType() {
+        return sideEffectType;
+    }
+
+    public MarginNewOrder sideEffectType(SideEffectType sideEffectType) {
+        this.sideEffectType = sideEffectType;
+        return this;
+    }
+
+    public Long getRecvWindow() {
+        return recvWindow;
+    }
+
+    public MarginNewOrder recvWindow(Long recvWindow) {
+        this.recvWindow = recvWindow;
+        return this;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public MarginNewOrder timestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    /**
+     * Places a MARKET buy order for the given <code>quantity</code>.
+     *
+     * @return a new order which is pre-configured with MARKET as the order type and BUY as the order side.
+     */
+    public static MarginNewOrder marketBuy(String symbol, String quantity) {
+        return new MarginNewOrder(symbol, OrderSide.BUY, OrderType.MARKET, null, quantity);
+    }
+
+    /**
+     * Places a MARKET sell order for the given <code>quantity</code>.
+     *
+     * @return a new order which is pre-configured with MARKET as the order type and SELL as the order side.
+     */
+    public static MarginNewOrder marketSell(String symbol, String quantity) {
+        return new MarginNewOrder(symbol, OrderSide.SELL, OrderType.MARKET, null, quantity);
+    }
+
+    /**
+     * Places a LIMIT buy order for the given <code>quantity</code> and <code>price</code>.
+     *
+     * @return a new order which is pre-configured with LIMIT as the order type and BUY as the order side.
+     */
+    public static MarginNewOrder limitBuy(String symbol, TimeInForce timeInForce, String quantity, String price) {
+        return new MarginNewOrder(symbol, OrderSide.BUY, OrderType.LIMIT, timeInForce, quantity, price);
+    }
+
+    /**
+     * Places a LIMIT sell order for the given <code>quantity</code> and <code>price</code>.
+     *
+     * @return a new order which is pre-configured with LIMIT as the order type and SELL as the order side.
+     */
+    public static MarginNewOrder limitSell(String symbol, TimeInForce timeInForce, String quantity, String price) {
+        return new MarginNewOrder(symbol, OrderSide.SELL, OrderType.LIMIT, timeInForce, quantity, price);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE)
+                .append("symbol", symbol)
+                .append("side", side)
+                .append("type", type)
+                .append("timeInForce", timeInForce)
+                .append("quantity", quantity)
+                .append("quoteOrderQty", quoteOrderQty)
+                .append("price", price)
+                .append("newClientOrderId", newClientOrderId)
+                .append("stopPrice", stopPrice)
+                .append("icebergQty", icebergQty)
+                .append("newOrderRespType", newOrderRespType)
+                .append("sideEffectType", sideEffectType)
+                .append("recvWindow", recvWindow)
+                .append("timestamp", timestamp)
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/api/client/domain/account/MarginNewOrderResponse.java
+++ b/src/main/java/com/binance/api/client/domain/account/MarginNewOrderResponse.java
@@ -1,0 +1,210 @@
+package com.binance.api.client.domain.account;
+
+import com.binance.api.client.constant.BinanceApiConstants;
+import com.binance.api.client.domain.OrderSide;
+import com.binance.api.client.domain.OrderStatus;
+import com.binance.api.client.domain.OrderType;
+import com.binance.api.client.domain.TimeInForce;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Response returned when placing a new order on the system.
+ *
+ * @see NewOrder for the request
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MarginNewOrderResponse {
+
+    /**
+     * Order symbol.
+     */
+    private String symbol;
+
+    /**
+     * Order id.
+     */
+    private Long orderId;
+
+    /**
+     * This will be either a generated one, or the newClientOrderId parameter
+     * which was passed when creating the new order.
+     */
+    private String clientOrderId;
+
+    private String price;
+
+    private String origQty;
+
+    private String executedQty;
+
+    private String cummulativeQuoteQty;
+
+    private OrderStatus status;
+
+    private TimeInForce timeInForce;
+
+    private OrderType type;
+
+    private String marginBuyBorrowAmount;
+
+    private String marginBuyBorrowAsset;
+
+    private OrderSide side;
+
+    // @JsonSetter(nulls = Nulls.AS_EMPTY)
+    private List<Trade> fills;
+
+    /**
+     * Transact time for this order.
+     */
+    private Long transactTime;
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getClientOrderId() {
+        return clientOrderId;
+    }
+
+    public void setClientOrderId(String clientOrderId) {
+        this.clientOrderId = clientOrderId;
+    }
+
+    public Long getTransactTime() {
+        return transactTime;
+    }
+
+    public void setTransactTime(Long transactTime) {
+        this.transactTime = transactTime;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public void setPrice(String price) {
+        this.price = price;
+    }
+
+    public String getOrigQty() {
+        return origQty;
+    }
+
+    public void setOrigQty(String origQty) {
+        this.origQty = origQty;
+    }
+
+    public String getExecutedQty() {
+        return executedQty;
+    }
+
+    public void setExecutedQty(String executedQty) {
+        this.executedQty = executedQty;
+    }
+
+    public String getCummulativeQuoteQty() {
+        return cummulativeQuoteQty;
+    }
+
+    public void setCummulativeQuoteQty(String cummulativeQuoteQty) {
+        this.cummulativeQuoteQty = cummulativeQuoteQty;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public TimeInForce getTimeInForce() {
+        return timeInForce;
+    }
+
+    public void setTimeInForce(TimeInForce timeInForce) {
+        this.timeInForce = timeInForce;
+    }
+
+    public OrderType getType() {
+        return type;
+    }
+
+    public void setType(OrderType type) {
+        this.type = type;
+    }
+
+    public String getMarginBuyBorrowAmount() {
+        return marginBuyBorrowAmount;
+    }
+
+    public void setMarginBuyBorrowAmount(String marginBuyBorrowAmount) {
+        this.marginBuyBorrowAmount = marginBuyBorrowAmount;
+    }
+
+    public String getMarginBuyBorrowAsset() {
+        return marginBuyBorrowAsset;
+    }
+
+    public void setMarginBuyBorrowAsset(String marginBuyBorrowAsset) {
+        this.marginBuyBorrowAsset = marginBuyBorrowAsset;
+    }
+
+    public OrderSide getSide() {
+        return side;
+    }
+
+    public void setSide(OrderSide side) {
+        this.side = side;
+    }
+
+    public List<Trade> getFills() {
+        return fills;
+    }
+
+    public void setFills(List<Trade> fills) {
+        this.fills = fills;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE)
+                .append("symbol", symbol)
+                .append("orderId", orderId)
+                .append("clientOrderId", clientOrderId)
+                .append("transactTime", transactTime)
+                .append("price", price)
+                .append("origQty", origQty)
+                .append("executedQty", executedQty)
+                .append("status", status)
+                .append("timeInForce", timeInForce)
+                .append("type", type)
+                .append("marginBuyBorrowAmount", marginBuyBorrowAmount)
+                .append("marginBuyBorrowAsset", marginBuyBorrowAsset)
+                .append("side", side)
+                .append("fills", Optional.ofNullable(fills).orElse(Collections.emptyList())
+                        .stream()
+                        .map(Object::toString)
+                        .collect(Collectors.joining(", ")))
+                .toString();
+    }
+}

--- a/src/main/java/com/binance/api/client/domain/account/SideEffectType.java
+++ b/src/main/java/com/binance/api/client/domain/account/SideEffectType.java
@@ -1,0 +1,17 @@
+package com.binance.api.client.domain.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Desired side-effect for margin orders:
+ * NO_SIDE_EFFECT for normal trade order;
+ * MARGIN_BUY for margin trade order;
+ * AUTO_REPAY for making auto repayment after order filled
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public enum SideEffectType {
+    NO_SIDE_EFFECT,
+    MARGIN_BUY,
+    AUTO_REPAY
+}
+

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncMarginRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncMarginRestClientImpl.java
@@ -20,84 +20,84 @@ import static com.binance.api.client.impl.BinanceApiServiceGenerator.createServi
  */
 public class BinanceApiAsyncMarginRestClientImpl implements BinanceApiAsyncMarginRestClient {
 
-  private final BinanceApiService binanceApiService;
+    private final BinanceApiService binanceApiService;
 
-  public BinanceApiAsyncMarginRestClientImpl(String apiKey, String secret) {
-    binanceApiService = createService(BinanceApiService.class, apiKey, secret);
-  }
+    public BinanceApiAsyncMarginRestClientImpl(String apiKey, String secret) {
+        binanceApiService = createService(BinanceApiService.class, apiKey, secret);
+    }
 
-  // Margin Account endpoints
+    // Margin Account endpoints
 
-  @Override
-  public void getAccount(Long recvWindow, Long timestamp, BinanceApiCallback<MarginAccount> callback) {
-    binanceApiService.getMarginAccount(recvWindow, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void getAccount(Long recvWindow, Long timestamp, BinanceApiCallback<MarginAccount> callback) {
+        binanceApiService.getMarginAccount(recvWindow, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void getAccount(BinanceApiCallback<MarginAccount> callback) {
-    long timestamp = System.currentTimeMillis();
-    binanceApiService.getMarginAccount(BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void getAccount(BinanceApiCallback<MarginAccount> callback) {
+        long timestamp = System.currentTimeMillis();
+        binanceApiService.getMarginAccount(BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void getOpenOrders(OrderRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
-      binanceApiService.getOpenMarginOrders(orderRequest.getSymbol(), orderRequest.getRecvWindow(),
-              orderRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void getOpenOrders(OrderRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
+        binanceApiService.getOpenMarginOrders(orderRequest.getSymbol(), orderRequest.getRecvWindow(),
+                orderRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback) {
-    binanceApiService.newMarginOrder(order.getSymbol(), order.getSide(), order.getType(),
-            order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-            order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void newOrder(MarginNewOrder order, BinanceApiCallback<MarginNewOrderResponse> callback) {
+        binanceApiService.newMarginOrder(order.getSymbol(), order.getSide(), order.getType(), order.getTimeInForce(),
+                order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(), order.getIcebergQty(),
+                order.getNewOrderRespType(), order.getSideEffectType(), order.getRecvWindow(), order.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void cancelOrder(CancelOrderRequest cancelOrderRequest, BinanceApiCallback<CancelOrderResponse> callback) {
-    binanceApiService.cancelMarginOrder(cancelOrderRequest.getSymbol(),
-            cancelOrderRequest.getOrderId(), cancelOrderRequest.getOrigClientOrderId(), cancelOrderRequest.getNewClientOrderId(),
-            cancelOrderRequest.getRecvWindow(), cancelOrderRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void cancelOrder(CancelOrderRequest cancelOrderRequest, BinanceApiCallback<CancelOrderResponse> callback) {
+        binanceApiService.cancelMarginOrder(cancelOrderRequest.getSymbol(),
+                cancelOrderRequest.getOrderId(), cancelOrderRequest.getOrigClientOrderId(), cancelOrderRequest.getNewClientOrderId(),
+                cancelOrderRequest.getRecvWindow(), cancelOrderRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void getOrderStatus(OrderStatusRequest orderStatusRequest, BinanceApiCallback<Order> callback) {
-    binanceApiService.getMarginOrderStatus(orderStatusRequest.getSymbol(),
-            orderStatusRequest.getOrderId(), orderStatusRequest.getOrigClientOrderId(),
-            orderStatusRequest.getRecvWindow(), orderStatusRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void getOrderStatus(OrderStatusRequest orderStatusRequest, BinanceApiCallback<Order> callback) {
+        binanceApiService.getMarginOrderStatus(orderStatusRequest.getSymbol(),
+                orderStatusRequest.getOrderId(), orderStatusRequest.getOrigClientOrderId(),
+                orderStatusRequest.getRecvWindow(), orderStatusRequest.getTimestamp()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback) {
-    binanceApiService.getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback) {
+        binanceApiService.getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  // user stream endpoints
+    // user stream endpoints
 
-  @Override
-  public void startUserDataStream(BinanceApiCallback<ListenKey> callback) {
-    binanceApiService.startMarginUserDataStream().enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void startUserDataStream(BinanceApiCallback<ListenKey> callback) {
+        binanceApiService.startMarginUserDataStream().enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void keepAliveUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
-    binanceApiService.keepAliveMarginUserDataStream(listenKey).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void keepAliveUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
+        binanceApiService.keepAliveMarginUserDataStream(listenKey).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void transfer(String asset, String amount, TransferType type, BinanceApiCallback<MarginTransaction> callback) {
-    long timestamp = System.currentTimeMillis();
-    binanceApiService.transfer(asset, amount, type.getValue(), BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void transfer(String asset, String amount, TransferType type, BinanceApiCallback<MarginTransaction> callback) {
+        long timestamp = System.currentTimeMillis();
+        binanceApiService.transfer(asset, amount, type.getValue(), BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void borrow(String asset, String amount, BinanceApiCallback<MarginTransaction> callback) {
-    long timestamp = System.currentTimeMillis();
-    binanceApiService.borrow(asset, amount, BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void borrow(String asset, String amount, BinanceApiCallback<MarginTransaction> callback) {
+        long timestamp = System.currentTimeMillis();
+        binanceApiService.borrow(asset, amount, BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 
-  @Override
-  public void repay(String asset, String amount, BinanceApiCallback<MarginTransaction> callback) {
-    long timestamp = System.currentTimeMillis();
-    binanceApiService.repay(asset, amount, BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
-  }
+    @Override
+    public void repay(String asset, String amount, BinanceApiCallback<MarginTransaction> callback) {
+        long timestamp = System.currentTimeMillis();
+        binanceApiService.repay(asset, amount, BinanceApiConstants.DEFAULT_MARGIN_RECEIVING_WINDOW, timestamp).enqueue(new BinanceApiCallbackAdapter<>(callback));
+    }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiMarginRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiMarginRestClientImpl.java
@@ -19,101 +19,101 @@ import static com.binance.api.client.impl.BinanceApiServiceGenerator.executeSync
  */
 public class BinanceApiMarginRestClientImpl implements BinanceApiMarginRestClient {
 
-  private final BinanceApiService binanceApiService;
+    private final BinanceApiService binanceApiService;
 
-  public BinanceApiMarginRestClientImpl(String apiKey, String secret) {
-    binanceApiService = createService(BinanceApiService.class, apiKey, secret);
-  }
+    public BinanceApiMarginRestClientImpl(String apiKey, String secret) {
+        binanceApiService = createService(BinanceApiService.class, apiKey, secret);
+    }
 
-  @Override
-  public MarginAccount getAccount() {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.getMarginAccount(BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
-  }
+    @Override
+    public MarginAccount getAccount() {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.getMarginAccount(BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
+    }
 
-  @Override
-  public List<Order> getOpenOrders(OrderRequest orderRequest) {
-    return executeSync(binanceApiService.getOpenMarginOrders(orderRequest.getSymbol(), orderRequest.getRecvWindow(),
-            orderRequest.getTimestamp()));
-  }
+    @Override
+    public List<Order> getOpenOrders(OrderRequest orderRequest) {
+        return executeSync(binanceApiService.getOpenMarginOrders(orderRequest.getSymbol(), orderRequest.getRecvWindow(),
+                orderRequest.getTimestamp()));
+    }
 
-  @Override
-  public NewOrderResponse newOrder(NewOrder order) {
-    return executeSync(binanceApiService.newMarginOrder(order.getSymbol(), order.getSide(), order.getType(),
-            order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
-            order.getIcebergQty(), order.getNewOrderRespType(), order.getRecvWindow(), order.getTimestamp()));
-  }
+    @Override
+    public MarginNewOrderResponse newOrder(MarginNewOrder order) {
+        return executeSync(binanceApiService.newMarginOrder(order.getSymbol(), order.getSide(), order.getType(),
+                order.getTimeInForce(), order.getQuantity(), order.getPrice(), order.getNewClientOrderId(), order.getStopPrice(),
+                order.getIcebergQty(), order.getNewOrderRespType(), order.getSideEffectType(), order.getRecvWindow(), order.getTimestamp()));
+    }
 
-  @Override
-  public CancelOrderResponse cancelOrder(CancelOrderRequest cancelOrderRequest) {
-    return executeSync(binanceApiService.cancelMarginOrder(cancelOrderRequest.getSymbol(),
-            cancelOrderRequest.getOrderId(), cancelOrderRequest.getOrigClientOrderId(), cancelOrderRequest.getNewClientOrderId(),
-            cancelOrderRequest.getRecvWindow(), cancelOrderRequest.getTimestamp()));
-  }
+    @Override
+    public CancelOrderResponse cancelOrder(CancelOrderRequest cancelOrderRequest) {
+        return executeSync(binanceApiService.cancelMarginOrder(cancelOrderRequest.getSymbol(),
+                cancelOrderRequest.getOrderId(), cancelOrderRequest.getOrigClientOrderId(), cancelOrderRequest.getNewClientOrderId(),
+                cancelOrderRequest.getRecvWindow(), cancelOrderRequest.getTimestamp()));
+    }
 
-  @Override
-  public Order getOrderStatus(OrderStatusRequest orderStatusRequest) {
-    return executeSync(binanceApiService.getMarginOrderStatus(orderStatusRequest.getSymbol(),
-            orderStatusRequest.getOrderId(), orderStatusRequest.getOrigClientOrderId(),
-            orderStatusRequest.getRecvWindow(), orderStatusRequest.getTimestamp()));
-  }
+    @Override
+    public Order getOrderStatus(OrderStatusRequest orderStatusRequest) {
+        return executeSync(binanceApiService.getMarginOrderStatus(orderStatusRequest.getSymbol(),
+                orderStatusRequest.getOrderId(), orderStatusRequest.getOrigClientOrderId(),
+                orderStatusRequest.getRecvWindow(), orderStatusRequest.getTimestamp()));
+    }
 
-  @Override
-  public List<Trade> getMyTrades(String symbol) {
-    return executeSync(binanceApiService.getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
-  }
+    @Override
+    public List<Trade> getMyTrades(String symbol) {
+        return executeSync(binanceApiService.getMyTrades(symbol, null, null, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+    }
 
-  // user stream endpoints
+    // user stream endpoints
 
-  @Override
-  public String startUserDataStream() {
-    return executeSync(binanceApiService.startMarginUserDataStream()).toString();
-  }
+    @Override
+    public String startUserDataStream() {
+        return executeSync(binanceApiService.startMarginUserDataStream()).toString();
+    }
 
-  @Override
-  public void keepAliveUserDataStream(String listenKey) {
-    executeSync(binanceApiService.keepAliveMarginUserDataStream(listenKey));
-  }
+    @Override
+    public void keepAliveUserDataStream(String listenKey) {
+        executeSync(binanceApiService.keepAliveMarginUserDataStream(listenKey));
+    }
 
-  @Override
-  public MarginTransaction transfer(String asset, String amount, TransferType type) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.transfer(asset, amount, type.getValue(), BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
-  }
+    @Override
+    public MarginTransaction transfer(String asset, String amount, TransferType type) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.transfer(asset, amount, type.getValue(), BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
+    }
 
-  @Override
-  public MarginTransaction borrow(String asset, String amount) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.borrow(asset, amount, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
-  }
+    @Override
+    public MarginTransaction borrow(String asset, String amount) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.borrow(asset, amount, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
+    }
 
-  @Override
-  public LoanQueryResult queryLoan(String asset, String txId) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.queryLoan(asset, txId, timestamp));
-  }
+    @Override
+    public LoanQueryResult queryLoan(String asset, String txId) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.queryLoan(asset, txId, timestamp));
+    }
 
-  @Override
-  public RepayQueryResult queryRepay(String asset, String txId) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.queryRepay(asset, txId, timestamp));
-  }
+    @Override
+    public RepayQueryResult queryRepay(String asset, String txId) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.queryRepay(asset, txId, timestamp));
+    }
 
-  @Override
-  public RepayQueryResult queryRepay(String asset, long startTime) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.queryRepay(asset, startTime, timestamp));
-  }
+    @Override
+    public RepayQueryResult queryRepay(String asset, long startTime) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.queryRepay(asset, startTime, timestamp));
+    }
 
-  @Override
-  public MaxBorrowableQueryResult queryMaxBorrowable(String asset) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.queryMaxBorrowable(asset, timestamp));
-  }
+    @Override
+    public MaxBorrowableQueryResult queryMaxBorrowable(String asset) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.queryMaxBorrowable(asset, timestamp));
+    }
 
-  @Override
-  public MarginTransaction repay(String asset, String amount) {
-    long timestamp = System.currentTimeMillis();
-    return executeSync(binanceApiService.repay(asset, amount, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
-  }
+    @Override
+    public MarginTransaction repay(String asset, String amount) {
+        long timestamp = System.currentTimeMillis();
+        return executeSync(binanceApiService.repay(asset, amount, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, timestamp));
+    }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiService.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiService.java
@@ -11,20 +11,9 @@ import com.binance.api.client.domain.event.ListenKey;
 import com.binance.api.client.domain.general.Asset;
 import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.general.ServerTime;
-import com.binance.api.client.domain.market.AggTrade;
-import com.binance.api.client.domain.market.BookTicker;
-import com.binance.api.client.domain.market.Candlestick;
-import com.binance.api.client.domain.market.OrderBook;
-import com.binance.api.client.domain.market.TickerPrice;
-import com.binance.api.client.domain.market.TickerStatistics;
+import com.binance.api.client.domain.market.*;
 import retrofit2.Call;
-import retrofit2.http.DELETE;
-import retrofit2.http.GET;
-import retrofit2.http.Headers;
-import retrofit2.http.POST;
-import retrofit2.http.PUT;
-import retrofit2.http.Query;
-import retrofit2.http.Url;
+import retrofit2.http.*;
 
 import java.util.List;
 
@@ -209,11 +198,11 @@ public interface BinanceApiService {
 
     @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
     @POST("/sapi/v1/margin/order")
-    Call<NewOrderResponse> newMarginOrder(@Query("symbol") String symbol, @Query("side") OrderSide side, @Query("type") OrderType type,
-                                          @Query("timeInForce") TimeInForce timeInForce, @Query("quantity") String quantity, @Query("price") String price,
-                                          @Query("newClientOrderId") String newClientOrderId, @Query("stopPrice") String stopPrice,
-                                          @Query("icebergQty") String icebergQty, @Query("newOrderRespType") NewOrderResponseType newOrderRespType,
-                                          @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
+    Call<MarginNewOrderResponse> newMarginOrder(@Query("symbol") String symbol, @Query("side") OrderSide side, @Query("type") OrderType type,
+                                                @Query("timeInForce") TimeInForce timeInForce, @Query("quantity") String quantity,
+                                                @Query("price") String price, @Query("newClientOrderId") String newClientOrderId, @Query("stopPrice") String stopPrice,
+                                                @Query("icebergQty") String icebergQty, @Query("newOrderRespType") NewOrderResponseType newOrderRespType,
+                                                @Query("sideEffectType") SideEffectType sideEffectType, @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
 
     @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
     @DELETE("/sapi/v1/margin/order")

--- a/src/test/java/com/binance/api/examples/MarginOrdersExample.java
+++ b/src/test/java/com/binance/api/examples/MarginOrdersExample.java
@@ -3,44 +3,47 @@ package com.binance.api.examples;
 import com.binance.api.client.BinanceApiClientFactory;
 import com.binance.api.client.BinanceApiMarginRestClient;
 import com.binance.api.client.domain.TimeInForce;
-import com.binance.api.client.domain.account.NewOrderResponse;
+import com.binance.api.client.domain.account.MarginNewOrderResponse;
 import com.binance.api.client.domain.account.NewOrderResponseType;
 import com.binance.api.client.domain.account.Order;
-import com.binance.api.client.domain.account.request.*;
+import com.binance.api.client.domain.account.request.CancelOrderRequest;
+import com.binance.api.client.domain.account.request.CancelOrderResponse;
+import com.binance.api.client.domain.account.request.OrderRequest;
+import com.binance.api.client.domain.account.request.OrderStatusRequest;
 import com.binance.api.client.exception.BinanceApiException;
 
 import java.util.List;
 
-import static com.binance.api.client.domain.account.NewOrder.limitBuy;
+import static com.binance.api.client.domain.account.MarginNewOrder.limitBuy;
 
 /**
  * Examples on how to place orders, cancel them, and query account information.
  */
 public class MarginOrdersExample {
 
-  public static void main(String[] args) {
-    BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_SECRET");
-    BinanceApiMarginRestClient client = factory.newMarginRestClient();
+    public static void main(String[] args) {
+        BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_SECRET");
+        BinanceApiMarginRestClient client = factory.newMarginRestClient();
 
-    // Getting list of open orders
-    List<Order> openOrders = client.getOpenOrders(new OrderRequest("LINKETH"));
-    System.out.println(openOrders);
+        // Getting list of open orders
+        List<Order> openOrders = client.getOpenOrders(new OrderRequest("LINKETH"));
+        System.out.println(openOrders);
 
-    // Get status of a particular order
-    Order order = client.getOrderStatus(new OrderStatusRequest("LINKETH", 751698L));
-    System.out.println(order);
+        // Get status of a particular order
+        Order order = client.getOrderStatus(new OrderStatusRequest("LINKETH", 751698L));
+        System.out.println(order);
 
-    // Canceling an order
-    try {
-      CancelOrderResponse cancelOrderResponse = client.cancelOrder(new CancelOrderRequest("LINKETH", 756762l));
-      System.out.println(cancelOrderResponse);
-    } catch (BinanceApiException e) {
-      System.out.println(e.getError().getMsg());
+        // Canceling an order
+        try {
+            CancelOrderResponse cancelOrderResponse = client.cancelOrder(new CancelOrderRequest("LINKETH", 756762l));
+            System.out.println(cancelOrderResponse);
+        } catch (BinanceApiException e) {
+            System.out.println(e.getError().getMsg());
+        }
+
+        // Placing a real LIMIT order
+        MarginNewOrderResponse newOrderResponse = client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001").newOrderRespType(NewOrderResponseType.FULL));
+        System.out.println(newOrderResponse);
     }
-
-    // Placing a real LIMIT order
-    NewOrderResponse newOrderResponse = client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001").newOrderRespType(NewOrderResponseType.FULL));
-    System.out.println(newOrderResponse);
-  }
 
 }

--- a/src/test/java/com/binance/api/examples/MarginOrdersExampleAsync.java
+++ b/src/test/java/com/binance/api/examples/MarginOrdersExampleAsync.java
@@ -7,30 +7,30 @@ import com.binance.api.client.domain.account.request.CancelOrderRequest;
 import com.binance.api.client.domain.account.request.OrderRequest;
 import com.binance.api.client.domain.account.request.OrderStatusRequest;
 
-import static com.binance.api.client.domain.account.NewOrder.limitBuy;
+import static com.binance.api.client.domain.account.MarginNewOrder.limitBuy;
 
 /**
  * Examples on how to place orders, cancel them, and query account information.
  */
 public class MarginOrdersExampleAsync {
 
-  public static void main(String[] args) {
-    BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_SECRET");
-    BinanceApiAsyncMarginRestClient client = factory.newAsyncMarginRestClient();
+    public static void main(String[] args) {
+        BinanceApiClientFactory factory = BinanceApiClientFactory.newInstance("YOUR_API_KEY", "YOUR_SECRET");
+        BinanceApiAsyncMarginRestClient client = factory.newAsyncMarginRestClient();
 
-    // Getting list of open orders
-    client.getOpenOrders(new OrderRequest("LINKETH"), response -> System.out.println(response));
+        // Getting list of open orders
+        client.getOpenOrders(new OrderRequest("LINKETH"), response -> System.out.println(response));
 
-    // Get status of a particular order
-    client.getOrderStatus(new OrderStatusRequest("LINKETH", 745262L),
-        response -> System.out.println(response));
+        // Get status of a particular order
+        client.getOrderStatus(new OrderStatusRequest("LINKETH", 745262L),
+                response -> System.out.println(response));
 
-    // Canceling an order
-    client.cancelOrder(new CancelOrderRequest("LINKETH", 756703L),
-        response -> System.out.println(response));
+        // Canceling an order
+        client.cancelOrder(new CancelOrderRequest("LINKETH", 756703L),
+                response -> System.out.println(response));
 
-    // Placing a real LIMIT order
-    client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001"),
-        response -> System.out.println(response));
-  }
+        // Placing a real LIMIT order
+        client.newOrder(limitBuy("LINKETH", TimeInForce.GTC, "1000", "0.0001"),
+                response -> System.out.println(response));
+    }
 }


### PR DESCRIPTION
### What does this PR do?

- Create separate classes for MarginNewOrder and MarginNewOrderResponse
- Add SideEffectType to MarginNewOrder
- Refactor some code.

### Where should the reviewer start?

- src/main/java/com/binance/api/client/domain/account/SideEffectType.java
- src/main/java/com/binance/api/client/domain/account/MarginNewOrder.java
- src/main/java/com/binance/api/client/domain/account/MarginNewOrderResponse.java 
- src/main/java/com/binance/api/client/impl/BinanceApiService.java
- src/main/java/com/binance/api/client/impl/BinanceApiMarginRestClientImpl.java
- src/main/java/com/binance/api/client/impl/BinanceApiAsyncMarginRestClientImpl.java

### How should this be manually tested?
- Placing a new margin order BinanceApiMarginRestClient.newOrder

### Any background context you want to provide?

The reason I went with separate classes for MarginNewOrder and MarginNewOrderResponse is because adding the new properties to NewOrder and NewOrderResponse would have made they usage confusing. Besides sideEffectType, the MarginNewOrder should also have the isIsolated property, which is currently not implemented. The same holds for MarginNewOrderResponse. I did not inherit MarginNewOrder from NewOrder and MarginNewOrderResponse from NewOrderResponse since it's not clear that this is the relationship between those. I could have extracted the common properties to a base class, but did not really see the benefit. 

See the [documentation change log](https://binance-docs.github.io/apidocs/spot/en/#change-log) for when the change was done:

![image](https://user-images.githubusercontent.com/1391294/99149664-c1e32600-268f-11eb-8fed-0f91750abaf9.png)
