### PR TITLE
Fix ping interval for websocket clients

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
+++ b/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
@@ -2,94 +2,91 @@ package com.binance.api.client;
 
 import com.binance.api.client.impl.*;
 
-import static com.binance.api.client.impl.BinanceApiServiceGenerator.getSharedClient;
-
 /**
  * A factory for creating BinanceApi client objects.
  */
 public class BinanceApiClientFactory {
 
-  /**
-   * API Key
-   */
-  private String apiKey;
+    /**
+     * API Key
+     */
+    private String apiKey;
 
-  /**
-   * Secret.
-   */
-  private String secret;
+    /**
+     * Secret.
+     */
+    private String secret;
 
-  /**
-   * Instantiates a new binance api client factory.
-   *
-   * @param apiKey the API key
-   * @param secret the Secret
-   */
-  private BinanceApiClientFactory(String apiKey, String secret) {
-    this.apiKey = apiKey;
-    this.secret = secret;
-  }
+    /**
+     * Instantiates a new binance api client factory.
+     *
+     * @param apiKey the API key
+     * @param secret the Secret
+     */
+    private BinanceApiClientFactory(String apiKey, String secret) {
+        this.apiKey = apiKey;
+        this.secret = secret;
+    }
 
-  /**
-   * New instance.
-   *
-   * @param apiKey the API key
-   * @param secret the Secret
-   *
-   * @return the binance api client factory
-   */
-  public static BinanceApiClientFactory newInstance(String apiKey, String secret) {
-    return new BinanceApiClientFactory(apiKey, secret);
-  }
+    /**
+     * New instance.
+     *
+     * @param apiKey the API key
+     * @param secret the Secret
+     * @return the binance api client factory
+     */
+    public static BinanceApiClientFactory newInstance(String apiKey, String secret) {
+        return new BinanceApiClientFactory(apiKey, secret);
+    }
 
-  /**
-   * New instance without authentication.
-   *
-   * @return the binance api client factory
-   */
-  public static BinanceApiClientFactory newInstance() {
-    return new BinanceApiClientFactory(null, null);
-  }
+    /**
+     * New instance without authentication.
+     *
+     * @return the binance api client factory
+     */
+    public static BinanceApiClientFactory newInstance() {
+        return new BinanceApiClientFactory(null, null);
+    }
 
-  /**
-   * Creates a new synchronous/blocking REST client.
-   */
-  public BinanceApiRestClient newRestClient() {
-    return new BinanceApiRestClientImpl(apiKey, secret);
-  }
+    /**
+     * Creates a new synchronous/blocking REST client.
+     */
+    public BinanceApiRestClient newRestClient() {
+        return new BinanceApiRestClientImpl(apiKey, secret);
+    }
 
-  /**
-   * Creates a new asynchronous/non-blocking REST client.
-   */
-  public BinanceApiAsyncRestClient newAsyncRestClient() {
-    return new BinanceApiAsyncRestClientImpl(apiKey, secret);
-  }
+    /**
+     * Creates a new asynchronous/non-blocking REST client.
+     */
+    public BinanceApiAsyncRestClient newAsyncRestClient() {
+        return new BinanceApiAsyncRestClientImpl(apiKey, secret);
+    }
 
-  /**
-   * Creates a new asynchronous/non-blocking Margin REST client.
-   */
-  public BinanceApiAsyncMarginRestClient newAsyncMarginRestClient() {
-    return new BinanceApiAsyncMarginRestClientImpl(apiKey, secret);
-  }
+    /**
+     * Creates a new asynchronous/non-blocking Margin REST client.
+     */
+    public BinanceApiAsyncMarginRestClient newAsyncMarginRestClient() {
+        return new BinanceApiAsyncMarginRestClientImpl(apiKey, secret);
+    }
 
-  /**
-   * Creates a new synchronous/blocking Margin REST client.
-   */
-  public BinanceApiMarginRestClient newMarginRestClient() {
-    return new BinanceApiMarginRestClientImpl(apiKey, secret);
-  }
+    /**
+     * Creates a new synchronous/blocking Margin REST client.
+     */
+    public BinanceApiMarginRestClient newMarginRestClient() {
+        return new BinanceApiMarginRestClientImpl(apiKey, secret);
+    }
 
-  /**
-   * Creates a new web socket client used for handling data streams.
-   */
-  public BinanceApiWebSocketClient newWebSocketClient() {
-    return new BinanceApiWebSocketClientImpl(getSharedClient());
-  }
+    /**
+     * Creates a new web socket client used for handling data streams.
+     */
+    public BinanceApiWebSocketClient newWebSocketClient() {
+        return new BinanceApiWebSocketClientImpl();
+    }
 
-  /**
-   * Creates a new synchronous/blocking Swap REST client.
-   */
-  public BinanceApiSwapRestClient newSwapRestClient() {
-    return new BinanceApiSwapRestClientImpl(apiKey, secret);
-  }
+    /**
+     * Creates a new synchronous/blocking Swap REST client.
+     */
+    public BinanceApiSwapRestClient newSwapRestClient() {
+        return new BinanceApiSwapRestClientImpl(apiKey, secret);
+    }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -13,7 +13,10 @@ import okhttp3.WebSocket;
 import java.io.Closeable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static com.binance.api.client.impl.BinanceApiServiceGenerator.getSharedClient;
 
 /**
  * Binance API WebSocket client implementation using OkHttp.
@@ -22,8 +25,8 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
 
     private final OkHttpClient client;
 
-    public BinanceApiWebSocketClientImpl(OkHttpClient client) {
-        this.client = client;
+    public BinanceApiWebSocketClientImpl() {
+        this.client = getSharedClient().newBuilder().pingInterval(3, TimeUnit.MINUTES).build();
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?

- Override the pingInterval of the OkHttpClient sharedClient for the BinanceApiWebSocketClients

### Where should the reviewer start?

- src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
- src/main/java/com/binance/api/client/BinanceApiClientFactory.java

### How should this be manually tested?

- Subscribing to a channel through a BinanceApiWebSocketClient

### Any background context you want to provide?
According to the documentation: 

> The websocket server will send a ping frame every 3 minutes. If the websocket server does not receive a pong frame back from the connection within a 10 minute period, the connection will be disconnected. Unsolicited pong frames are allowed.

The current implementation uses the same pingInterval for all clients, and it has a value of 20s. This works for a while, but then starts failing with _java.net.SocketTimeoutException: sent ping but didn't receive pong within 20000ms_.

Setting the pingInterval to 3 minutes as per the documentation fixes the issue. I have been running the client with the fix in production for a few days already, and have not encountered the error, while before, I would get it an hour after the app restart, and every 20 seconds after the first failure.