### PR TITLE
Fix signature calculation for URL encoded characters

### DIFF
--- a/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
@@ -43,7 +43,7 @@ public class AuthenticationInterceptor implements Interceptor {
 
         // Endpoint requires signing the payload
         if (isSignatureRequired) {
-            String payload = original.url().query();
+            String payload = original.url().encodedQuery();
             if (!StringUtils.isEmpty(payload)) {
                 String signature = HmacSHA256Signer.sign(payload, secret);
                 HttpUrl signedUrl = original.url().newBuilder().addQueryParameter("signature", signature).build();


### PR DESCRIPTION
Fixing issue #297 

Took me a while, but I've identified a bug in 'AuthenticationInterceptor'.

Maybe it was not needed yet, but when I was locally implementing support for sub-account APIs and some of the query string parameters where containing email address then the request was failing with 'msg':
`-1022:Signature for this request is not valid`

The issue is that 'AuthenticationInterceptor' is creating the SHA256 signature from original query string, for example:
`email=foo@bar.com`

But it needs to be calculating it from URL encoded query string, for example:
`email=foo%40bar.com`