### PR TITLE
Sub-account transfer API support

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiRestClient.java
@@ -6,6 +6,7 @@ import com.binance.api.client.domain.account.DepositHistory;
 import com.binance.api.client.domain.account.NewOrder;
 import com.binance.api.client.domain.account.NewOrderResponse;
 import com.binance.api.client.domain.account.Order;
+import com.binance.api.client.domain.account.SubAccountTransfer;
 import com.binance.api.client.domain.account.Trade;
 import com.binance.api.client.domain.account.TradeHistoryItem;
 import com.binance.api.client.domain.account.WithdrawHistory;
@@ -15,8 +16,8 @@ import com.binance.api.client.domain.account.request.CancelOrderRequest;
 import com.binance.api.client.domain.account.request.CancelOrderResponse;
 import com.binance.api.client.domain.account.request.OrderRequest;
 import com.binance.api.client.domain.account.request.OrderStatusRequest;
-import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.general.Asset;
+import com.binance.api.client.domain.general.ExchangeInfo;
 import com.binance.api.client.domain.market.AggTrade;
 import com.binance.api.client.domain.market.BookTicker;
 import com.binance.api.client.domain.market.Candlestick;
@@ -273,6 +274,17 @@ public interface BinanceApiRestClient {
    */
   DepositAddress getDepositAddress(String asset);
 
+  /**
+   * Transfer assets from/to main account and sub-account
+   * 
+   * @param fromEmail Sender sub-account email
+   * @param toEmail Recipient sub-account email
+   * @param asset Asset to transfer
+   * @param amount Amount to transfer
+   * @return SubAccountTransfer response
+   */
+  SubAccountTransfer subAccountTransfer(String fromEmail, String toEmail, String asset, String amount);
+  
   // User stream endpoints
 
   /**

--- a/src/main/java/com/binance/api/client/domain/account/SubAccountTransfer.java
+++ b/src/main/java/com/binance/api/client/domain/account/SubAccountTransfer.java
@@ -1,0 +1,38 @@
+package com.binance.api.client.domain.account;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.binance.api.client.constant.BinanceApiConstants;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SubAccountTransfer {
+
+    private boolean success;
+    private String txnId;
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getTxnId() {
+        return txnId;
+    }
+
+    public void setTxnId(String txnId) {
+        this.txnId = txnId;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, BinanceApiConstants.TO_STRING_BUILDER_STYLE)
+                .append("success", success)
+                .append("txnId", txnId)
+                .toString();
+    }
+
+}

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -207,6 +207,11 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
     return executeSync(binanceApiService.getDepositAddress(asset, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
   }
 
+  @Override
+  public SubAccountTransfer subAccountTransfer(String fromEmail, String toEmail, String asset, String amount) {
+    return executeSync(binanceApiService.subAccountTransfer(fromEmail, toEmail, asset, amount, BinanceApiConstants.DEFAULT_RECEIVING_WINDOW, System.currentTimeMillis()));
+  }
+
   // User stream endpoints
 
   @Override

--- a/src/main/java/com/binance/api/client/impl/BinanceApiService.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiService.java
@@ -145,6 +145,10 @@ public interface BinanceApiService {
     @GET("/wapi/v3/depositAddress.html")
     Call<DepositAddress> getDepositAddress(@Query("asset") String asset, @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
 
+    @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
+    @POST("/wapi/v3/sub-account/transfer.html")
+    Call<SubAccountTransfer> subAccountTransfer(@Query("fromEmail") String fromEmail, @Query("toEmail") String toEmail, @Query("asset") String asset, @Query("amount") String amount, @Query("recvWindow") Long recvWindow, @Query("timestamp") Long timestamp);
+
     // User stream endpoints
 
     @Headers(BinanceApiConstants.ENDPOINT_SECURITY_TYPE_APIKEY_HEADER)


### PR DESCRIPTION
Adding support for `POST /wapi/v3/sub-account/transfer.html` API to allow asset transfer from/to main account and sub-account.

**BEWARE! This is dependent on a bugfix in:** https://github.com/binance-exchange/binance-java-api/pull/298
- so thatbugfix needs to be merged first