### PR TITLE
add new SymbolFilter fields

### DIFF
--- a/src/main/java/com/binance/api/client/domain/general/SymbolFilter.java
+++ b/src/main/java/com/binance/api/client/domain/general/SymbolFilter.java
@@ -77,6 +77,13 @@ public class SymbolFilter {
    */
   private String limit;
 
+  // percent_price
+  private String multiplierUp;
+
+  private String multiplierDown;
+
+  private Integer avgPriceMins;
+
   public FilterType getFilterType() {
     return filterType;
   }
@@ -156,5 +163,29 @@ public class SymbolFilter {
 
   public void setLimit(String limit) {
     this.limit = limit;
+  }
+
+  public String getMultiplierUp() {
+    return multiplierUp;
+  }
+
+  public void setMultiplierUp(String multiplierUp) {
+    this.multiplierUp = multiplierUp;
+  }
+
+  public String getMultiplierDown() {
+    return multiplierDown;
+  }
+
+  public void setMultiplierDown(String multiplierDown) {
+    this.multiplierDown = multiplierDown;
+  }
+
+  public Integer getAvgPriceMins() {
+    return avgPriceMins;
+  }
+
+  public void setAvgPriceMins(Integer avgPriceMins) {
+    this.avgPriceMins = avgPriceMins;
   }
 }

--- a/src/main/java/com/binance/api/client/domain/general/SymbolFilter.java
+++ b/src/main/java/com/binance/api/client/domain/general/SymbolFilter.java
@@ -84,6 +84,8 @@ public class SymbolFilter {
 
   private Integer avgPriceMins;
 
+  private Boolean applyToMarket;
+
   public FilterType getFilterType() {
     return filterType;
   }
@@ -187,5 +189,13 @@ public class SymbolFilter {
 
   public void setAvgPriceMins(Integer avgPriceMins) {
     this.avgPriceMins = avgPriceMins;
+  }
+
+  public boolean getApplyToMarket(){ 
+    return applyToMarket;
+  }
+
+  public void setApplyToMarket(boolean applyToMarket) {
+    this.applyToMarket = applyToMarket;
   }
 }


### PR DESCRIPTION
This branch adds new fields to SymbolFilter to support [PERCENT_PRICE](https://github.com/binance-us/binance-official-api-docs/blob/master/rest-api.md#percent_price) (multiplierUp, multiplierDown, avgPriceMins) and [MIN_NOTIONAL](https://github.com/binance-us/binance-official-api-docs/blob/master/rest-api.md#min_notional) (applyToMarket, avgPriceMins)
