### PR TITLE
fixed the ability to do testnet streaming per #379

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,17 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.10</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.6</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
+++ b/src/main/java/com/binance/api/client/config/BinanceApiConfig.java
@@ -77,6 +77,6 @@ public class BinanceApiConfig {
      * Streaming Spot Test Network base URL.
      */
     public static String getStreamTestNetBaseUrl() {
-        return String.format("wss://%s", TESTNET_DOMAIN);
+        return String.format("wss://%s/ws", TESTNET_DOMAIN);
     }
 }

--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -58,8 +58,8 @@ public class BinanceApiServiceGenerator {
         String baseUrl = null;
         if (!BinanceApiConfig.useTestnet) { baseUrl = BinanceApiConfig.getApiBaseUrl(); }
         else {
-            baseUrl = BinanceApiConfig.useTestnetStreaming ?
-                BinanceApiConfig.getStreamTestNetBaseUrl() :
+            baseUrl = /*BinanceApiConfig.useTestnetStreaming ?
+                BinanceApiConfig.getStreamTestNetBaseUrl() :*/
                 BinanceApiConfig.getTestNetBaseUrl();
         }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiWebSocketClientImpl.java
@@ -93,7 +93,7 @@ public class BinanceApiWebSocketClientImpl implements BinanceApiWebSocketClient,
     }
 
     private Closeable createNewWebSocket(String channel, BinanceApiWebSocketListener<?> listener) {
-        String streamingUrl = String.format("%s/%s", BinanceApiConfig.getStreamApiBaseUrl(), channel);
+        String streamingUrl = String.format("%s/%s", BinanceApiConfig.useTestnetStreaming?BinanceApiConfig.getStreamTestNetBaseUrl():BinanceApiConfig.getStreamApiBaseUrl(), channel);
         Request request = new Request.Builder().url(streamingUrl).build();
         final WebSocket webSocket = client.newWebSocket(request, listener);
         return () -> {


### PR DESCRIPTION
#379 shows that the current codebase was never tested with testnet streaming api, this is a quick fix. my repo also was subject to maven-latest-revisions plugin, those look helpful going forward, or at least mostly harmless.
 