### PR TITLE
Fix deserialization issue for RateLimitType

### DIFF
--- a/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
+++ b/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
@@ -8,5 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public enum RateLimitType {
   REQUEST_WEIGHT,
-  ORDERS
+  ORDERS,
+  RAW_REQUESTS
 }


### PR DESCRIPTION
* Cannot deserialize value of type `com.binance.api.client.domain.general.RateLimitType` from String "RAW_REQUESTS": not one of the values accepted for Enum class: [REQUEST_WEIGHT, ORDERS]