### PR TITLE
Fix examples now too. Deprecated the usage of the old naming. 

### DIFF
--- a/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEvent.java
+++ b/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEvent.java
@@ -24,7 +24,7 @@ public class UserDataUpdateEvent {
 
   private long eventTime;
 
-  private AccountUpdateEvent accountUpdateEvent;
+  private AccountUpdateEvent outboundAccountPositionUpdateEvent;
 
   private BalanceUpdateEvent balanceUpdateEvent;
 
@@ -46,12 +46,20 @@ public class UserDataUpdateEvent {
     this.eventTime = eventTime;
   }
 
+  /**
+   * @Deprecated: left in for backwards compatibility. Use getOutboundAccountPositionUpdateEvent() instead, as that is what the Binance API documentation calls it.
+   */
+  @Deprecated
   public AccountUpdateEvent getAccountUpdateEvent() {
-    return accountUpdateEvent;
+    return outboundAccountPositionUpdateEvent;
   }
 
-  public void setAccountUpdateEvent(AccountUpdateEvent accountUpdateEvent) {
-    this.accountUpdateEvent = accountUpdateEvent;
+  public AccountUpdateEvent getOutboundAccountPositionUpdateEvent() {
+    return outboundAccountPositionUpdateEvent;
+  }
+
+  public void setOutboundAccountPositionUpdateEvent(AccountUpdateEvent accountUpdateEvent) {
+    this.outboundAccountPositionUpdateEvent = accountUpdateEvent;
   }
 
   public BalanceUpdateEvent getBalanceUpdateEvent() {
@@ -76,7 +84,7 @@ public class UserDataUpdateEvent {
         .append("eventType", eventType)
         .append("eventTime", eventTime);
     if (eventType == UserDataUpdateEventType.ACCOUNT_POSITION_UPDATE) {
-      sb.append("accountPositionUpdateEvent", accountUpdateEvent);
+      sb.append("outboundAccountPositionUpdateEvent", outboundAccountPositionUpdateEvent);
     } else if (eventType == UserDataUpdateEventType.BALANCE_UPDATE) {
       sb.append("balanceUpdateEvent", balanceUpdateEvent);
     } else {
@@ -86,8 +94,11 @@ public class UserDataUpdateEvent {
   }
 
   public enum UserDataUpdateEventType {
+    /** Corresponds to "outboundAccountPosition" events. */
     ACCOUNT_POSITION_UPDATE("outboundAccountPosition"),
+    /** Corresponds to "balanceUpdate" events. */
     BALANCE_UPDATE("balanceUpdate"),
+    /** Corresponds to "executionReport" events. */
     ORDER_TRADE_UPDATE("executionReport"),
     ;
 

--- a/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEventDeserializer.java
+++ b/src/main/java/com/binance/api/client/domain/event/UserDataUpdateEventDeserializer.java
@@ -41,7 +41,7 @@ public class UserDataUpdateEventDeserializer extends JsonDeserializer<UserDataUp
 
     if (userDataUpdateEventType == UserDataUpdateEventType.ACCOUNT_POSITION_UPDATE) {
       AccountUpdateEvent accountUpdateEvent = getUserDataUpdateEventDetail(json, AccountUpdateEvent.class, mapper);
-      userDataUpdateEvent.setAccountUpdateEvent(accountUpdateEvent);
+      userDataUpdateEvent.setOutboundAccountPositionUpdateEvent(accountUpdateEvent);
     } else if (userDataUpdateEventType == UserDataUpdateEventType.BALANCE_UPDATE) {
       BalanceUpdateEvent balanceUpdateEvent = getUserDataUpdateEventDetail(json, BalanceUpdateEvent.class, mapper);
       userDataUpdateEvent.setBalanceUpdateEvent(balanceUpdateEvent);

--- a/src/test/java/com/binance/api/examples/AccountBalanceCacheExample.java
+++ b/src/test/java/com/binance/api/examples/AccountBalanceCacheExample.java
@@ -9,7 +9,7 @@ import com.binance.api.client.domain.account.AssetBalance;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static com.binance.api.client.domain.event.UserDataUpdateEvent.UserDataUpdateEventType.ACCOUNT_UPDATE;
+import static com.binance.api.client.domain.event.UserDataUpdateEvent.UserDataUpdateEventType.ACCOUNT_POSITION_UPDATE;
 
 /**
  * Illustrates how to use the user data event stream to create a local cache for the balance of an account.
@@ -58,9 +58,9 @@ public class AccountBalanceCacheExample {
     BinanceApiWebSocketClient client = clientFactory.newWebSocketClient();
 
     client.onUserDataUpdateEvent(listenKey, response -> {
-      if (response.getEventType() == ACCOUNT_UPDATE) {
+      if (response.getEventType() == ACCOUNT_POSITION_UPDATE) {
         // Override cached asset balances
-        for (AssetBalance assetBalance : response.getAccountUpdateEvent().getBalances()) {
+        for (AssetBalance assetBalance : response.getOutboundAccountPositionUpdateEvent().getBalances()) {
           accountBalanceCache.put(assetBalance.getAsset(), assetBalance);
         }
         System.out.println(accountBalanceCache);

--- a/src/test/java/com/binance/api/examples/MarginUserDataStreamExample.java
+++ b/src/test/java/com/binance/api/examples/MarginUserDataStreamExample.java
@@ -28,8 +28,8 @@ public class MarginUserDataStreamExample {
 
     // Listen for changes in the account
     webSocketClient.onUserDataUpdateEvent(listenKey, response -> {
-      if (response.getEventType() == UserDataUpdateEventType.ACCOUNT_UPDATE) {
-        AccountUpdateEvent accountUpdateEvent = response.getAccountUpdateEvent();
+      if (response.getEventType() == UserDataUpdateEventType.ACCOUNT_POSITION_UPDATE) {
+        AccountUpdateEvent accountUpdateEvent = response.getOutboundAccountPositionUpdateEvent();
         // Print new balances of every available asset
         System.out.println(accountUpdateEvent.getBalances());
       } else {

--- a/src/test/java/com/binance/api/examples/UserDataStreamExample.java
+++ b/src/test/java/com/binance/api/examples/UserDataStreamExample.java
@@ -27,8 +27,8 @@ public class UserDataStreamExample {
 
     // Listen for changes in the account
     webSocketClient.onUserDataUpdateEvent(listenKey, response -> {
-      if (response.getEventType() == UserDataUpdateEventType.ACCOUNT_UPDATE) {
-        AccountUpdateEvent accountUpdateEvent = response.getAccountUpdateEvent();
+      if (response.getEventType() == UserDataUpdateEventType.ACCOUNT_POSITION_UPDATE) {
+        AccountUpdateEvent accountUpdateEvent = response.getOutboundAccountPositionUpdateEvent();
         // Print new balances of every available asset
         System.out.println(accountUpdateEvent.getBalances());
       } else {


### PR DESCRIPTION
The enum itself is left in place for backwards compatibility. This is a follow up to #386 in response to @brintal.