### PR TITLE
#402 - Secret key should be stored as a byte[]

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
+++ b/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
@@ -17,7 +17,7 @@ public class BinanceApiClientFactory {
   /**
    * Secret.
    */
-  private String secret;
+  private byte[] secret;
 
   /**
    * Instantiates a new binance api client factory.
@@ -25,7 +25,7 @@ public class BinanceApiClientFactory {
    * @param apiKey the API key
    * @param secret the Secret
    */
-  private BinanceApiClientFactory(String apiKey, String secret) {
+  private BinanceApiClientFactory(String apiKey, byte[] secret) {
     this.apiKey = apiKey;
     this.secret = secret;
     BinanceApiConfig.useTestnet = false;
@@ -40,7 +40,7 @@ public class BinanceApiClientFactory {
    * @param useTestnet true if endpoint is spot test network URL; false if endpoint is production spot API URL.
    * @param useTestnetStreaming true for spot test network websocket streaming; false for no streaming.
    */
-  private BinanceApiClientFactory(String apiKey, String secret, boolean useTestnet, boolean useTestnetStreaming) {
+  private BinanceApiClientFactory(String apiKey, byte[] secret, boolean useTestnet, boolean useTestnetStreaming) {
       this(apiKey, secret);
       if (useTestnet) {
         BinanceApiConfig.useTestnet = true;
@@ -55,8 +55,22 @@ public class BinanceApiClientFactory {
    *
    * @return the binance api client factory
    */
-  public static BinanceApiClientFactory newInstance(String apiKey, String secret) {
+  public static BinanceApiClientFactory newInstance(String apiKey, byte[] secret) {
     return new BinanceApiClientFactory(apiKey, secret);
+  }
+
+  /**
+   * New instance.
+   *
+   * @param apiKey the API key
+   * @param secret the Secret
+   *
+   * @return the binance api client factory
+   * @deprecated use byte[] to store the secret
+   */
+  @Deprecated
+  public static BinanceApiClientFactory newInstance(String apiKey, String secret) {
+    return newInstance(apiKey, secret.getBytes());
   }
 
   /**
@@ -69,10 +83,25 @@ public class BinanceApiClientFactory {
    *
    * @return the binance api client factory.
    */
-    public static BinanceApiClientFactory newInstance(String apiKey, String secret, boolean useTestnet, boolean useTestnetStreaming) {
+    public static BinanceApiClientFactory newInstance(String apiKey, byte[] secret, boolean useTestnet, boolean useTestnetStreaming) {
       return new BinanceApiClientFactory(apiKey, secret, useTestnet, useTestnetStreaming);
   }
 
+  /**
+   * New instance with optional Spot Test Network endpoint.
+   *
+   * @param apiKey the API key
+   * @param secret the Secret
+   * @param useTestnet true if endpoint is spot test network URL; false if endpoint is production spot API URL.
+   * @param useTestnetStreaming true for spot test network websocket streaming; false for no streaming.
+   *
+   * @return the binance api client factory.
+   * @deprecated use byte[] to store the secret
+   */
+  @Deprecated
+  public static BinanceApiClientFactory newInstance(String apiKey, String secret, boolean useTestnet, boolean useTestnetStreaming) {
+    return newInstance(apiKey, secret.getBytes(), useTestnet, useTestnetStreaming);
+  }
   /**
    * New instance without authentication.
    *

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncMarginRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncMarginRestClientImpl.java
@@ -22,7 +22,7 @@ public class BinanceApiAsyncMarginRestClientImpl implements BinanceApiAsyncMargi
 
     private final BinanceApiService binanceApiService;
 
-    public BinanceApiAsyncMarginRestClientImpl(String apiKey, String secret) {
+    public BinanceApiAsyncMarginRestClientImpl(String apiKey, byte[] secret) {
         binanceApiService = createService(BinanceApiService.class, apiKey, secret);
     }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientImpl.java
@@ -42,7 +42,7 @@ public class BinanceApiAsyncRestClientImpl implements BinanceApiAsyncRestClient 
 
   private final BinanceApiService binanceApiService;
 
-  public BinanceApiAsyncRestClientImpl(String apiKey, String secret) {
+  public BinanceApiAsyncRestClientImpl(String apiKey, byte[] secret) {
     binanceApiService = createService(BinanceApiService.class, apiKey, secret);
   }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiMarginRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiMarginRestClientImpl.java
@@ -21,7 +21,7 @@ public class BinanceApiMarginRestClientImpl implements BinanceApiMarginRestClien
 
     private final BinanceApiService binanceApiService;
 
-    public BinanceApiMarginRestClientImpl(String apiKey, String secret) {
+    public BinanceApiMarginRestClientImpl(String apiKey, byte[] secret) {
         binanceApiService = createService(BinanceApiService.class, apiKey, secret);
     }
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiRestClientImpl.java
@@ -23,7 +23,7 @@ public class BinanceApiRestClientImpl implements BinanceApiRestClient {
 
 	private final BinanceApiService binanceApiService;
 
-	public BinanceApiRestClientImpl(String apiKey, String secret) {
+	public BinanceApiRestClientImpl(String apiKey, byte[] secret) {
 		binanceApiService = createService(BinanceApiService.class, apiKey, secret);
 	}
 

--- a/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiServiceGenerator.java
@@ -7,6 +7,7 @@ import com.binance.api.client.security.AuthenticationInterceptor;
 import okhttp3.Dispatcher;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import retrofit2.Call;
 import retrofit2.Converter;
@@ -54,7 +55,7 @@ public class BinanceApiServiceGenerator {
      *
      * @return a new implementation of the API endpoints for the Binance API service.
      */
-    public static <S> S createService(Class<S> serviceClass, String apiKey, String secret) {
+    public static <S> S createService(Class<S> serviceClass, String apiKey, byte[] secret) {
         String baseUrl = null;
         if (!BinanceApiConfig.useTestnet) { baseUrl = BinanceApiConfig.getApiBaseUrl(); }
         else {
@@ -67,7 +68,7 @@ public class BinanceApiServiceGenerator {
                 .baseUrl(baseUrl)
                 .addConverterFactory(converterFactory);
 
-        if (StringUtils.isEmpty(apiKey) || StringUtils.isEmpty(secret)) {
+        if (StringUtils.isEmpty(apiKey) || ArrayUtils.isEmpty(secret)) {
             retrofitBuilder.client(sharedClient);
         } else {
             // `adaptedClient` will use its own interceptor, but share thread pool etc with the 'parent' client

--- a/src/main/java/com/binance/api/client/impl/BinanceApiSwapRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiSwapRestClientImpl.java
@@ -17,7 +17,7 @@ public class BinanceApiSwapRestClientImpl implements BinanceApiSwapRestClient {
 
     private final BinanceApiService binanceApiService;
 
-    public BinanceApiSwapRestClientImpl(String apiKey, String secret) {
+    public BinanceApiSwapRestClientImpl(String apiKey, byte[] secret) {
         binanceApiService = createService(BinanceApiService.class, apiKey, secret);
     }
 

--- a/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/binance/api/client/security/AuthenticationInterceptor.java
@@ -19,9 +19,9 @@ public class AuthenticationInterceptor implements Interceptor {
 
     private final String apiKey;
 
-    private final String secret;
+    private final byte[] secret;
 
-    public AuthenticationInterceptor(String apiKey, String secret) {
+    public AuthenticationInterceptor(String apiKey, byte[] secret) {
         this.apiKey = apiKey;
         this.secret = secret;
     }

--- a/src/main/java/com/binance/api/client/security/HmacSHA256Signer.java
+++ b/src/main/java/com/binance/api/client/security/HmacSHA256Signer.java
@@ -16,10 +16,10 @@ public class HmacSHA256Signer {
    * @param secret secret key
    * @return a signed message
    */
-  public static String sign(String message, String secret) {
+  public static String sign(String message, byte[] secret) {
     try {
       Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
-      SecretKeySpec secretKeySpec = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+      SecretKeySpec secretKeySpec = new SecretKeySpec(secret, "HmacSHA256");
       sha256_HMAC.init(secretKeySpec);
       return new String(Hex.encodeHex(sha256_HMAC.doFinal(message.getBytes())));
     } catch (Exception e) {


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html#PBEEx

However, here's the caveat: Objects of type String are immutable, i.e., there are no methods defined that allow you to change (overwrite) or zero out the contents of a String after usage. This feature makes String objects unsuitable for storing security sensitive information such as user passwords.