### PR TITLE
issue #409 API should allow integration with ExecutorService to allow…

### DIFF
--- a/src/main/java/com/binance/api/client/BinanceApiAsyncExecutorRestClient.java
+++ b/src/main/java/com/binance/api/client/BinanceApiAsyncExecutorRestClient.java
@@ -1,0 +1,309 @@
+package com.binance.api.client;
+
+import com.binance.api.client.domain.account.*;
+import com.binance.api.client.domain.account.request.*;
+import com.binance.api.client.domain.event.ListenKey;
+import com.binance.api.client.domain.general.Asset;
+import com.binance.api.client.domain.general.ExchangeInfo;
+import com.binance.api.client.domain.general.ServerTime;
+import com.binance.api.client.domain.market.*;
+
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * Binance API facade, supporting asynchronous/non-blocking access Binance's REST API using ExecutorServices to
+ * handling the request and response threading.
+ */
+public interface BinanceApiAsyncExecutorRestClient {
+
+  // General endpoints
+
+  /**
+   * Test connectivity to the Rest API.
+   * @return
+   */
+  Future<Void> ping(BinanceApiCallback<Void> callback);
+
+  /**
+   * Check server time.
+   * @return
+   */
+  Future<ServerTime> getServerTime(BinanceApiCallback<ServerTime> callback);
+
+  /**
+   * Current exchange trading rules and symbol information
+   *
+   * @return
+   */
+  Future<ExchangeInfo> getExchangeInfo(BinanceApiCallback<ExchangeInfo> callback);
+
+  /**
+   * ALL supported assets and whether or not they can be withdrawn.
+   *
+   * @return
+   */
+  Future<List<Asset>> getAllAssets(BinanceApiCallback<List<Asset>> callback);
+
+  // Market Data endpoints
+
+  /**
+   * Get order book of a symbol (asynchronous)
+   *
+   * @param symbol ticker symbol (e.g. ETHBTC)
+   * @param limit depth of the order book (max 100)
+   * @param callback the callback that handles the response
+   *
+   * @return
+   */
+  Future<OrderBook> getOrderBook(String symbol, Integer limit, BinanceApiCallback<OrderBook> callback);
+
+  /**
+   * Get recent trades (up to last 500). Weight: 1
+   *
+   * @param symbol ticker symbol (e.g. ETHBTC)
+   * @param limit of last trades (Default 500; max 1000.)
+   * @param callback the callback that handles the response
+   *
+   * @return
+   */
+  Future<List<TradeHistoryItem>> getTrades(String symbol, Integer limit, BinanceApiCallback<List<TradeHistoryItem>> callback);
+
+  /**
+   * Get older trades. Weight: 5
+   *
+   * @param symbol ticker symbol (e.g. ETHBTC)
+   * @param limit of last trades (Default 500; max 1000.)
+   * @param fromId TradeId to fetch from. Default gets most recent trades.
+   * @param callback the callback that handles the response
+   *
+   * @return
+   */
+  Future<List<TradeHistoryItem>> getHistoricalTrades(String symbol, Integer limit, Long fromId, BinanceApiCallback<List<TradeHistoryItem>> callback);
+
+  /**
+   * Get compressed, aggregate trades. Trades that fill at the time, from the same order, with
+   * the same price will have the quantity aggregated.
+   *
+   * If both <code>startTime</code> and <code>endTime</code> are sent, <code>limit</code>should not
+   * be sent AND the distance between <code>startTime</code> and <code>endTime</code> must be less than 24 hours.
+   *
+   * @param symbol symbol to aggregate (mandatory)
+   * @param fromId ID to get aggregate trades from INCLUSIVE (optional)
+   * @param limit Default 500; max 1000 (optional)
+   * @param startTime Timestamp in ms to get aggregate trades from INCLUSIVE (optional).
+   * @param endTime Timestamp in ms to get aggregate trades until INCLUSIVE (optional).
+   * @param callback the callback that handles the response
+   * @return a list of aggregate trades for the given symbol
+   */
+  Future<List<AggTrade>> getAggTrades(String symbol, String fromId, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<AggTrade>> callback);
+
+  /**
+   * Return the most recent aggregate trades for <code>symbol</code>
+   *
+   * @see #getAggTrades(String, String, Integer, Long, Long, BinanceApiCallback)
+   */
+  Future<List<AggTrade>> getAggTrades(String symbol, BinanceApiCallback<List<AggTrade>> callback);
+
+  /**
+   * Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+   *
+   * @param symbol symbol to aggregate (mandatory)
+   * @param interval candlestick interval (mandatory)
+   * @param limit Default 500; max 1000 (optional)
+   * @param startTime Timestamp in ms to get candlestick bars from INCLUSIVE (optional).
+   * @param endTime Timestamp in ms to get candlestick bars until INCLUSIVE (optional).
+   * @param callback the callback that handles the response containing a candlestick bar for the given symbol and interval
+   */
+  Future<List<Candlestick>> getCandlestickBars(String symbol, CandlestickInterval interval, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<Candlestick>> callback);
+
+  /**
+   * Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+   *
+   * @see #getCandlestickBars(String, CandlestickInterval, BinanceApiCallback)
+   */
+  Future<List<Candlestick>> getCandlestickBars(String symbol, CandlestickInterval interval, BinanceApiCallback<List<Candlestick>> callback);
+
+  /**
+   * Get 24 hour price change statistics (asynchronous).
+   *
+   * @param symbol ticker symbol (e.g. ETHBTC)
+   * @param callback the callback that handles the response
+   */
+  Future<TickerStatistics> get24HrPriceStatistics(String symbol, BinanceApiCallback<TickerStatistics> callback);
+  
+  /**
+   * Get 24 hour price change statistics for all symbols (asynchronous).
+   * 
+   * @param callback the callback that handles the response
+   */
+  Future<List<TickerStatistics>> getAll24HrPriceStatistics(BinanceApiCallback<List<TickerStatistics>> callback);
+
+  /**
+   * Get Latest price for all symbols (asynchronous).
+   *
+   * @param callback the callback that handles the response
+   */
+  Future<List<TickerPrice>> getAllPrices(BinanceApiCallback<List<TickerPrice>> callback);
+  
+  /**
+   * Get latest price for <code>symbol</code> (asynchronous).
+   * 
+   * @param symbol ticker symbol (e.g. ETHBTC)
+   * @param callback the callback that handles the response
+   */
+  Future<TickerPrice> getPrice(String symbol , BinanceApiCallback<TickerPrice> callback);
+
+  /**
+   * Get best price/qty on the order book for all symbols (asynchronous).
+   *
+   * @param callback the callback that handles the response
+   */
+  Future<List<BookTicker>> getBookTickers(BinanceApiCallback<List<BookTicker>> callback);
+
+  // Account endpoints
+
+  /**
+   * Send in a new order (asynchronous)
+   *
+   * @param order the new order to submit.
+   * @param callback the callback that handles the response
+   */
+  Future<NewOrderResponse> newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback);
+
+  /**
+   * Test new order creation and signature/recvWindow long. Creates and validates a new order but does not send it into the matching engine.
+   *
+   * @param order the new TEST order to submit.
+   * @param callback the callback that handles the response
+   */
+  Future<Void> newOrderTest(NewOrder order, BinanceApiCallback<Void> callback);
+
+  /**
+   * Check an order's status (asynchronous).
+   *
+   * @param orderStatusRequest order status request parameters
+   * @param callback the callback that handles the response
+   */
+  Future<Order> getOrderStatus(OrderStatusRequest orderStatusRequest, BinanceApiCallback<Order> callback);
+
+  /**
+   * Cancel an active order (asynchronous).
+   *
+   * @param cancelOrderRequest order status request parameters
+   * @param callback the callback that handles the response
+   */
+  Future<CancelOrderResponse> cancelOrder(CancelOrderRequest cancelOrderRequest, BinanceApiCallback<CancelOrderResponse> callback);
+
+  /**
+   * Get all open orders on a symbol (asynchronous).
+   *
+   * @param orderRequest order request parameters
+   * @param callback the callback that handles the response
+   */
+  Future<List<Order>> getOpenOrders(OrderRequest orderRequest, BinanceApiCallback<List<Order>> callback);
+
+  /**
+   * Get all account orders; active, canceled, or filled.
+   *
+   * @param orderRequest order request parameters
+   * @param callback the callback that handles the response
+   */
+  Future<List<Order>> getAllOrders(AllOrdersRequest orderRequest, BinanceApiCallback<List<Order>> callback);
+
+  /**
+   * Get current account information (async).
+   */
+  Future<Account> getAccount(Long recvWindow, Long timestamp, BinanceApiCallback<Account> callback);
+
+  /**
+   * Get current account information using default parameters (async).
+   */
+  Future<Account> getAccount(BinanceApiCallback<Account> callback);
+
+  /**
+   * Get trades for a specific account and symbol.
+   *
+   * @param symbol symbol to get trades from
+   * @param limit default 500; max 1000
+   * @param fromId TradeId to fetch from. Default gets most recent trades.
+   * @param callback the callback that handles the response with a list of trades
+   */
+  Future<List<Trade>> getMyTrades(String symbol, Integer limit, Long fromId, Long recvWindow, Long timestamp, BinanceApiCallback<List<Trade>> callback);
+
+  /**
+   * Get trades for a specific account and symbol.
+   *
+   * @param symbol symbol to get trades from
+   * @param limit default 500; max 1000
+   * @param callback the callback that handles the response with a list of trades
+   */
+  Future<List<Trade>> getMyTrades(String symbol, Integer limit, BinanceApiCallback<List<Trade>> callback);
+
+  /**
+   * Get trades for a specific account and symbol.
+   *
+   * @param symbol symbol to get trades from
+   * @param callback the callback that handles the response with a list of trades
+   */
+  Future<List<Trade>> getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback);
+
+  /**
+   * Submit a withdraw request.
+   *
+   * Enable Withdrawals option has to be active in the API settings.
+   *
+   * @param asset asset symbol to withdraw
+   * @param address address to withdraw to
+   * @param amount amount to withdraw
+   * @param name description/alias of the address
+   * @param addressTag Secondary address identifier for coins like XRP,XMR etc.
+   */
+  Future<WithdrawResult> withdraw(String asset, String address, String amount, String name, String addressTag, BinanceApiCallback<WithdrawResult> callback);
+
+  /**
+   * Fetch account deposit history.
+   *
+   * @param callback the callback that handles the response and returns the deposit history
+   */
+  Future<DepositHistory> getDepositHistory(String asset, BinanceApiCallback<DepositHistory> callback);
+
+  /**
+   * Fetch account withdraw history.
+   *
+   * @param callback the callback that handles the response and returns the withdraw history
+   */
+  Future<WithdrawHistory> getWithdrawHistory(String asset, BinanceApiCallback<WithdrawHistory> callback);
+
+  /**
+   * Fetch deposit address.
+   *
+   * @param callback the callback that handles the response and returns the deposit address
+   */
+  Future<DepositAddress> getDepositAddress(String asset, BinanceApiCallback<DepositAddress> callback);
+
+  // User stream endpoints
+
+  /**
+   * Start a new user data stream.
+   *
+   * @param callback the callback that handles the response which contains a listenKey
+   */
+  Future<ListenKey> startUserDataStream(BinanceApiCallback<ListenKey> callback);
+
+  /**
+   * PING a user data stream to prevent a time out.
+   *
+   * @param listenKey listen key that identifies a data stream
+   * @param callback the callback that handles the response which contains a listenKey
+   */
+  Future<Void> keepAliveUserDataStream(String listenKey, BinanceApiCallback<Void> callback);
+
+  /**
+   * Close out a new user data stream.
+   *
+   * @param listenKey listen key that identifies a data stream
+   * @param callback the callback that handles the response which contains a listenKey
+   */
+  Future<Void> closeUserDataStream(String listenKey, BinanceApiCallback<Void> callback);
+}

--- a/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
+++ b/src/main/java/com/binance/api/client/BinanceApiClientFactory.java
@@ -2,6 +2,9 @@ package com.binance.api.client;
 
 import com.binance.api.client.impl.*;
 import com.binance.api.client.config.BinanceApiConfig;
+
+import java.util.concurrent.ExecutorService;
+
 import static com.binance.api.client.impl.BinanceApiServiceGenerator.getSharedClient;
 
 /**
@@ -99,6 +102,19 @@ public class BinanceApiClientFactory {
    */
   public BinanceApiRestClient newRestClient() {
     return new BinanceApiRestClientImpl(apiKey, secret);
+  }
+
+  /**
+   * Creates a new asynchronous/non-blocking REST client that uses Executor Services for handling
+   * the request and response threading.
+   *
+   * @param requestService
+   * @param responseService
+   * @return
+   */
+  public BinanceApiAsyncExecutorRestClient newAsyncExecutorRestClient(ExecutorService requestService,
+                                                                      ExecutorService responseService) {
+    return new BinanceApiAsyncExecutorRestClientImpl(newRestClient(), requestService, responseService);
   }
 
   /**

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncExecutorRestClientImpl.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncExecutorRestClientImpl.java
@@ -1,0 +1,234 @@
+package com.binance.api.client.impl;
+
+import com.binance.api.client.BinanceApiAsyncExecutorRestClient;
+import com.binance.api.client.BinanceApiCallback;
+import com.binance.api.client.BinanceApiRestClient;
+import com.binance.api.client.domain.account.*;
+import com.binance.api.client.domain.account.request.*;
+import com.binance.api.client.domain.event.ListenKey;
+import com.binance.api.client.domain.general.Asset;
+import com.binance.api.client.domain.general.ExchangeInfo;
+import com.binance.api.client.domain.general.ServerTime;
+import com.binance.api.client.domain.market.*;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of BinanceApiAsyncExecutorRestClient using ExecutorServices for handling request and responses.
+ */
+public class BinanceApiAsyncExecutorRestClientImpl implements BinanceApiAsyncExecutorRestClient {
+    private final BinanceApiRestClient client;
+    private final ExecutorService requestService;
+    private final ExecutorService responseService;
+
+    public BinanceApiAsyncExecutorRestClientImpl(BinanceApiRestClient client, ExecutorService requestService, ExecutorService responseService) {
+        this.client = client;
+        this.requestService = requestService;
+        this.responseService = responseService;
+    }
+
+    private <T> Future<T> invoke(BinanceApiCallback<T> callback, Supplier<T> t){
+        return requestService.submit(() -> {
+            try {
+                T v = t.get();
+                responseService.submit(() -> callback.onResponse(v));
+                return v;
+            }catch (Exception e){
+                responseService.submit(() -> callback.onFailure(e));
+                throw e;
+            }
+        });
+    }
+
+    @Override
+    public Future<Void> ping(BinanceApiCallback<Void> callback) {
+        return invoke(callback,() -> {
+            client.ping();
+            return null;
+        });
+    }
+
+    @Override
+    public Future<ServerTime> getServerTime(BinanceApiCallback<ServerTime> callback) {
+        return invoke(callback, () -> {
+            ServerTime t = new ServerTime();
+            t.setServerTime(client.getServerTime());
+            return t;
+        });
+    }
+
+    @Override
+    public Future<ExchangeInfo> getExchangeInfo(BinanceApiCallback<ExchangeInfo> callback) {
+        return invoke(callback, () -> client.getExchangeInfo());
+    }
+
+    @Override
+    public Future<List<Asset>> getAllAssets(BinanceApiCallback<List<Asset>> callback) {
+        return invoke(callback, () -> client.getAllAssets());
+    }
+
+    @Override
+    public Future<OrderBook> getOrderBook(String symbol, Integer limit, BinanceApiCallback<OrderBook> callback) {
+        return invoke(callback, () -> client.getOrderBook(symbol,limit));
+    }
+
+    @Override
+    public Future<List<TradeHistoryItem>> getTrades(String symbol, Integer limit, BinanceApiCallback<List<TradeHistoryItem>> callback) {
+        return invoke(callback, () -> client.getTrades(symbol, limit));
+    }
+
+    @Override
+    public Future<List<TradeHistoryItem>> getHistoricalTrades(String symbol, Integer limit, Long fromId, BinanceApiCallback<List<TradeHistoryItem>> callback) {
+        return invoke(callback, () -> client.getHistoricalTrades(symbol, limit, fromId));
+    }
+
+    @Override
+    public Future<List<AggTrade>> getAggTrades(String symbol, String fromId, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<AggTrade>> callback) {
+        return invoke(callback, () -> client.getAggTrades(symbol,fromId,limit,startTime,endTime));
+    }
+
+    @Override
+    public Future<List<AggTrade>> getAggTrades(String symbol, BinanceApiCallback<List<AggTrade>> callback) {
+        return invoke(callback, () -> client.getAggTrades(symbol));
+    }
+
+    @Override
+    public Future<List<Candlestick>> getCandlestickBars(String symbol, CandlestickInterval interval, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<Candlestick>> callback) {
+        return invoke(callback, () -> client.getCandlestickBars(symbol,interval,limit,startTime, endTime));
+    }
+
+    @Override
+    public Future<List<Candlestick>> getCandlestickBars(String symbol, CandlestickInterval interval, BinanceApiCallback<List<Candlestick>> callback) {
+        return invoke(callback, () -> client.getCandlestickBars(symbol, interval));
+    }
+
+    @Override
+    public Future<TickerStatistics> get24HrPriceStatistics(String symbol, BinanceApiCallback<TickerStatistics> callback) {
+        return invoke(callback, () -> client.get24HrPriceStatistics(symbol));
+    }
+
+    @Override
+    public Future<List<TickerStatistics>> getAll24HrPriceStatistics(BinanceApiCallback<List<TickerStatistics>> callback) {
+        return invoke(callback, () -> client.getAll24HrPriceStatistics());
+    }
+
+    @Override
+    public Future<List<TickerPrice>> getAllPrices(BinanceApiCallback<List<TickerPrice>> callback) {
+        return invoke(callback, () -> client.getAllPrices());
+    }
+
+    @Override
+    public Future<TickerPrice> getPrice(String symbol, BinanceApiCallback<TickerPrice> callback) {
+        return invoke(callback, () -> client.getPrice(symbol));
+    }
+
+    @Override
+    public Future<List<BookTicker>> getBookTickers(BinanceApiCallback<List<BookTicker>> callback) {
+        return invoke(callback, () -> client.getBookTickers());
+    }
+
+    @Override
+    public Future<NewOrderResponse> newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback) {
+        return invoke(callback, () -> client.newOrder(order));
+    }
+
+    @Override
+    public Future<Void> newOrderTest(NewOrder order, BinanceApiCallback<Void> callback) {
+        return invoke(callback, () -> {
+            client.newOrderTest(order);
+            return null;
+        });
+    }
+
+    @Override
+    public Future<Order> getOrderStatus(OrderStatusRequest orderStatusRequest, BinanceApiCallback<Order> callback) {
+        return invoke(callback, () -> client.getOrderStatus(orderStatusRequest));
+    }
+
+    @Override
+    public Future<CancelOrderResponse> cancelOrder(CancelOrderRequest cancelOrderRequest, BinanceApiCallback<CancelOrderResponse> callback) {
+        return invoke(callback, () -> client.cancelOrder(cancelOrderRequest));
+    }
+
+    @Override
+    public Future<List<Order>> getOpenOrders(OrderRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
+        return invoke(callback, () -> client.getOpenOrders(orderRequest));
+    }
+
+    @Override
+    public Future<List<Order>> getAllOrders(AllOrdersRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
+        return invoke(callback, () -> client.getAllOrders(orderRequest));
+    }
+
+    @Override
+    public Future<Account> getAccount(Long recvWindow, Long timestamp, BinanceApiCallback<Account> callback) {
+        return invoke(callback, () -> client.getAccount(recvWindow, timestamp));
+    }
+
+    @Override
+    public Future<Account> getAccount(BinanceApiCallback<Account> callback) {
+        return invoke(callback, () -> client.getAccount());
+    }
+
+    @Override
+    public Future<List<Trade>> getMyTrades(String symbol, Integer limit, Long fromId, Long recvWindow, Long timestamp, BinanceApiCallback<List<Trade>> callback) {
+        return invoke(callback, () -> client.getMyTrades(symbol, limit, fromId, recvWindow, timestamp));
+    }
+
+    @Override
+    public Future<List<Trade>> getMyTrades(String symbol, Integer limit, BinanceApiCallback<List<Trade>> callback) {
+        return invoke(callback, () -> client.getMyTrades(symbol, limit));
+    }
+
+    @Override
+    public Future<List<Trade>> getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback) {
+        return invoke(callback, () -> client.getMyTrades(symbol));
+    }
+
+    @Override
+    public Future<WithdrawResult> withdraw(String asset, String address, String amount, String name, String addressTag, BinanceApiCallback<WithdrawResult> callback) {
+        return invoke(callback, () -> client.withdraw(asset, address, amount, name, addressTag));
+    }
+
+    @Override
+    public Future<DepositHistory> getDepositHistory(String asset, BinanceApiCallback<DepositHistory> callback) {
+        return invoke(callback, () -> client.getDepositHistory(asset));
+    }
+
+    @Override
+    public Future<WithdrawHistory> getWithdrawHistory(String asset, BinanceApiCallback<WithdrawHistory> callback) {
+        return invoke(callback, () -> client.getWithdrawHistory(asset));
+    }
+
+    @Override
+    public Future<DepositAddress> getDepositAddress(String asset, BinanceApiCallback<DepositAddress> callback) {
+        return invoke(callback, () -> client.getDepositAddress(asset));
+    }
+
+    @Override
+    public Future<ListenKey> startUserDataStream(BinanceApiCallback<ListenKey> callback) {
+        return invoke(callback, () -> {
+            client.startUserDataStream();
+            return null;
+        });
+    }
+
+    @Override
+    public Future<Void> keepAliveUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
+        return invoke(callback, () -> {
+            client.keepAliveUserDataStream(listenKey);
+            return null;
+        });
+    }
+
+    @Override
+    public Future<Void> closeUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
+        return invoke(callback, () -> {
+            client.closeUserDataStream(listenKey);
+            return null;
+        });
+    }
+}

--- a/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientAdapter.java
+++ b/src/main/java/com/binance/api/client/impl/BinanceApiAsyncRestClientAdapter.java
@@ -1,0 +1,198 @@
+package com.binance.api.client.impl;
+
+import com.binance.api.client.BinanceApiAsyncExecutorRestClient;
+import com.binance.api.client.BinanceApiAsyncRestClient;
+import com.binance.api.client.BinanceApiCallback;
+import com.binance.api.client.domain.account.*;
+import com.binance.api.client.domain.account.request.*;
+import com.binance.api.client.domain.event.ListenKey;
+import com.binance.api.client.domain.general.Asset;
+import com.binance.api.client.domain.general.ExchangeInfo;
+import com.binance.api.client.domain.general.ServerTime;
+import com.binance.api.client.domain.market.*;
+
+import java.util.List;
+
+/**
+ * Adapter to make calls to a BinanceApiAsyncExecutorRestClient using the BinanceApiAsyncRestClient
+ * interface.  This allows existing code to migrate to use BinanceApiAsyncExecutorRestClient with dedicated
+ * ExecutorServices without a major lift.
+ * If you are writing new code, consider to use BinanceApiAsyncExecutorRestClient directly.
+ */
+public class BinanceApiAsyncRestClientAdapter implements BinanceApiAsyncRestClient {
+    private BinanceApiAsyncExecutorRestClient delegate;
+
+    public BinanceApiAsyncRestClientAdapter(BinanceApiAsyncExecutorRestClient delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void ping(BinanceApiCallback<Void> callback) {
+        delegate.ping(callback);
+    }
+
+    @Override
+    public void getServerTime(BinanceApiCallback<ServerTime> callback) {
+        delegate.getServerTime(callback);
+    }
+
+    @Override
+    public void getExchangeInfo(BinanceApiCallback<ExchangeInfo> callback) {
+        delegate.getExchangeInfo(callback);
+    }
+
+    @Override
+    public void getAllAssets(BinanceApiCallback<List<Asset>> callback) {
+        delegate.getAllAssets(callback);
+    }
+
+    @Override
+    public void getOrderBook(String symbol, Integer limit, BinanceApiCallback<OrderBook> callback) {
+        delegate.getOrderBook(symbol, limit,callback);
+    }
+
+    @Override
+    public void getTrades(String symbol, Integer limit, BinanceApiCallback<List<TradeHistoryItem>> callback) {
+        delegate.getTrades(symbol, limit,callback);
+    }
+
+    @Override
+    public void getHistoricalTrades(String symbol, Integer limit, Long fromId, BinanceApiCallback<List<TradeHistoryItem>> callback) {
+        delegate.getHistoricalTrades(symbol, limit, fromId,callback);
+    }
+
+    @Override
+    public void getAggTrades(String symbol, String fromId, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<AggTrade>> callback) {
+        delegate.getAggTrades(symbol, fromId,limit, startTime, endTime, callback);
+    }
+
+    @Override
+    public void getAggTrades(String symbol, BinanceApiCallback<List<AggTrade>> callback) {
+        delegate.getAggTrades(symbol, callback);
+    }
+
+    @Override
+    public void getCandlestickBars(String symbol, CandlestickInterval interval, Integer limit, Long startTime, Long endTime, BinanceApiCallback<List<Candlestick>> callback) {
+        delegate.getCandlestickBars(symbol, interval, limit, startTime, endTime,callback);
+    }
+
+    @Override
+    public void getCandlestickBars(String symbol, CandlestickInterval interval, BinanceApiCallback<List<Candlestick>> callback) {
+        delegate.getCandlestickBars(symbol, interval,callback);
+    }
+
+    @Override
+    public void get24HrPriceStatistics(String symbol, BinanceApiCallback<TickerStatistics> callback) {
+        delegate.get24HrPriceStatistics(symbol,callback);
+    }
+
+    @Override
+    public void getAll24HrPriceStatistics(BinanceApiCallback<List<TickerStatistics>> callback) {
+        delegate.getAll24HrPriceStatistics(callback);
+    }
+
+    @Override
+    public void getAllPrices(BinanceApiCallback<List<TickerPrice>> callback) {
+        delegate.getAllPrices(callback);
+    }
+
+    @Override
+    public void getPrice(String symbol, BinanceApiCallback<TickerPrice> callback) {
+        delegate.getPrice(symbol,callback);
+    }
+
+    @Override
+    public void getBookTickers(BinanceApiCallback<List<BookTicker>> callback) {
+        delegate.getBookTickers(callback);
+    }
+
+    @Override
+    public void newOrder(NewOrder order, BinanceApiCallback<NewOrderResponse> callback) {
+        delegate.newOrder(order,callback);
+    }
+
+    @Override
+    public void newOrderTest(NewOrder order, BinanceApiCallback<Void> callback) {
+        delegate.newOrderTest(order,callback);
+    }
+
+    @Override
+    public void getOrderStatus(OrderStatusRequest orderStatusRequest, BinanceApiCallback<Order> callback) {
+        delegate.getOrderStatus(orderStatusRequest,callback);
+    }
+
+    @Override
+    public void cancelOrder(CancelOrderRequest cancelOrderRequest, BinanceApiCallback<CancelOrderResponse> callback) {
+        delegate.cancelOrder(cancelOrderRequest,callback);
+    }
+
+    @Override
+    public void getOpenOrders(OrderRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
+        delegate.getOpenOrders(orderRequest,callback);
+    }
+
+    @Override
+    public void getAllOrders(AllOrdersRequest orderRequest, BinanceApiCallback<List<Order>> callback) {
+        delegate.getAllOrders(orderRequest,callback);
+    }
+
+    @Override
+    public void getAccount(Long recvWindow, Long timestamp, BinanceApiCallback<Account> callback) {
+        delegate.getAccount(recvWindow,timestamp,callback);
+    }
+
+    @Override
+    public void getAccount(BinanceApiCallback<Account> callback) {
+        delegate.getAccount(callback);
+    }
+
+    @Override
+    public void getMyTrades(String symbol, Integer limit, Long fromId, Long recvWindow, Long timestamp, BinanceApiCallback<List<Trade>> callback) {
+        delegate.getMyTrades(symbol, limit,fromId, recvWindow, timestamp,callback);
+    }
+
+    @Override
+    public void getMyTrades(String symbol, Integer limit, BinanceApiCallback<List<Trade>> callback) {
+        delegate.getMyTrades(symbol, limit,callback);
+    }
+
+    @Override
+    public void getMyTrades(String symbol, BinanceApiCallback<List<Trade>> callback) {
+        delegate.getMyTrades(symbol, callback);
+    }
+
+    @Override
+    public void withdraw(String asset, String address, String amount, String name, String addressTag, BinanceApiCallback<WithdrawResult> callback) {
+        delegate.withdraw(asset, address,amount, name, addressTag,callback);
+    }
+
+    @Override
+    public void getDepositHistory(String asset, BinanceApiCallback<DepositHistory> callback) {
+        delegate.getDepositHistory(asset, callback);
+    }
+
+    @Override
+    public void getWithdrawHistory(String asset, BinanceApiCallback<WithdrawHistory> callback) {
+        delegate.getWithdrawHistory(asset, callback);
+    }
+
+    @Override
+    public void getDepositAddress(String asset, BinanceApiCallback<DepositAddress> callback) {
+        delegate.getDepositAddress(asset, callback);
+    }
+
+    @Override
+    public void startUserDataStream(BinanceApiCallback<ListenKey> callback) {
+        delegate.startUserDataStream(callback);
+    }
+
+    @Override
+    public void keepAliveUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
+        delegate.keepAliveUserDataStream(listenKey, callback);
+    }
+
+    @Override
+    public void closeUserDataStream(String listenKey, BinanceApiCallback<Void> callback) {
+        delegate.closeUserDataStream(listenKey, callback);
+    }
+}


### PR DESCRIPTION
https://github.com/binance-exchange/binance-java-api/issues/409

When you make an asynchronous call there is no control of how many threads are used for the requests and responses. Particularly when responses are processed the client needs to ensure data integrity, this could be done using synchronization but its better achieved using intelligent threading and dispatching. This is even more important when connecting to more than one exchange and you need to ensure that responses for the same ticker across multiple exchanges are processed in order.

The most simple way to achieve this is to control the threading model for the async calls, rather than relying on the http library.
