### PR TITLE
issue/424 Adding missing entries in the FilterType enum

### DIFF
--- a/src/main/java/com/binance/api/client/domain/general/FilterType.java
+++ b/src/main/java/com/binance/api/client/domain/general/FilterType.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public enum FilterType {
   // Symbol
   PRICE_FILTER,
+  PERCENT_PRICE_BY_SIDE,
   LOT_SIZE,
   MIN_NOTIONAL,
+  NOTIONAL,
   MAX_NUM_ORDERS,
   MAX_ALGO_ORDERS,
   MAX_NUM_ALGO_ORDERS,
@@ -19,8 +21,11 @@ public enum FilterType {
   MARKET_LOT_SIZE,
   MAX_NUM_ICEBERG_ORDERS,
   MAX_POSITION,
+  TRAILING_DELTA,
 
   // Exchange
   EXCHANGE_MAX_NUM_ORDERS,
+  EXCHANGE_MAX_NUM_ALGO_ORDERS,
+  EXCHANGE_MAX_NUM_ICEBERG_ORDERS,
   EXCHANGE_MAX_ALGO_ORDERS
 }


### PR DESCRIPTION
This fixes the com.binance.api.client.BinanceApiRestClient#getExchangeInfo method